### PR TITLE
remove python 3.3 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ environment:
     matrix:
         - PYTHON: C:\Python27
           TOXENV: py27-test
-        - PYTHON: C:\Python33
-          TOXENV: py33-test
         - PYTHON: C:\Python34
           TOXENV: py34-test
         - PYTHON: C:\Python35

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: PyPy',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,33,34,35}-{test,cov}, py{27,33}-flake8
+envlist = py{27,34,35}-{test,cov}, py{27,34}-flake8
 
 [_test]
 deps =
@@ -24,9 +24,9 @@ passenv =
     NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =
     {test,cov}: {[_test]deps}
-    py{27,33}-flake8: {[_flake8]deps}
+    py{27,34}-flake8: {[_flake8]deps}
 commands =
     cov: nosetests --with-coverage {posargs}
     test: nosetests {posargs}
     py27-flake8: flake8 --min-version 2.7 {posargs} {[_flake8]files}
-    py33-flake8: flake8 --min-version 3.3 {posargs} {[_flake8]files}
+    py34-flake8: flake8 --min-version 3.4 {posargs} {[_flake8]files}


### PR DESCRIPTION
Python 3.3 was released 4 years ago, and doesn't seem to be shipped
on any modern distribution. Python 3.2 is supported by the previous
Debian release, but that one doesn't support `u''`
