### PR TITLE
Include test/__init__.py and test/rsrc in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,15 @@
 include LICENSE README.rst
 
+# Include the Sphinx documentation.
 recursive-include docs *.rst *.py Makefile *.png
 prune docs/_build
+
+# Include tests without pyc etc.
+prune test
+recursive-include test/rsrc *
+recursive-exclude test/rsrc *.pyc
+recursive-exclude test/rsrc *.pyo
+include test/*.py
 
 # Exclude junk.
 global-exclude .DS_Store


### PR DESCRIPTION
Without these files tests can't be run directly from the unpacked sdist tarball. Closes #13.