### PR TITLE
format R128 GAIN tags as Q7.8 number

### DIFF
--- a/mediafile.py
+++ b/mediafile.py
@@ -1408,7 +1408,11 @@ class CoverArtField(MediaField):
 
 
 class QNumberField(MediaField):
-    """
+    """Access integer-represented Q number fields.
+
+    Access a fixed-point fraction as a float. The stored value is shifted by
+    `fraction_bits` binary digits to the left and then rounded, yielding a
+    simple integer.
     """
     def __init__(self, fraction_bits, *args, **kwargs):
         super(QNumberField, self).__init__(out_type=int, *args, **kwargs)
@@ -1421,7 +1425,8 @@ class QNumberField(MediaField):
         return q_num / pow(2, self.__fraction_bits)
 
     def __set__(self, mediafile, value):
-        q_num = int(round(value * pow(2, self.__fraction_bits)))
+        q_num = round(value * pow(2, self.__fraction_bits))
+        q_num = int(q_num)  # needed for py2.7
         super(QNumberField, self).__set__(mediafile, q_num)
 
 

--- a/mediafile.py
+++ b/mediafile.py
@@ -1407,6 +1407,24 @@ class CoverArtField(MediaField):
         delattr(mediafile, 'images')
 
 
+class QNumberField(MediaField):
+    """
+    """
+    def __init__(self, fraction_bits, *args, **kwargs):
+        super(QNumberField, self).__init__(out_type=int, *args, **kwargs)
+        self.__fraction_bits = fraction_bits
+
+    def __get__(self, mediafile, owner=None):
+        q_num = super(QNumberField, self).__get__(mediafile, owner)
+        if q_num is None:
+            return None
+        return q_num / pow(2, self.__fraction_bits)
+
+    def __set__(self, mediafile, value):
+        q_num = int(round(value * pow(2, self.__fraction_bits)))
+        super(QNumberField, self).__set__(mediafile, q_num)
+
+
 class ImageListField(ListMediaField):
     """Descriptor to access the list of images embedded in tags.
 
@@ -2015,7 +2033,8 @@ class MediaFile(object):
     )
 
     # EBU R128 fields.
-    r128_track_gain = MediaField(
+    r128_track_gain = QNumberField(
+        8,
         MP3DescStorageStyle(
             u'R128_TRACK_GAIN'
         ),
@@ -2028,9 +2047,9 @@ class MediaFile(object):
         ASFStorageStyle(
             u'R128_TRACK_GAIN'
         ),
-        out_type=int,
     )
-    r128_album_gain = MediaField(
+    r128_album_gain = QNumberField(
+        8,
         MP3DescStorageStyle(
             u'R128_ALBUM_GAIN'
         ),
@@ -2043,7 +2062,6 @@ class MediaFile(object):
         ASFStorageStyle(
             u'R128_ALBUM_GAIN'
         ),
-        out_type=int,
     )
 
     initial_key = MediaField(

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -548,6 +548,23 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertEqual(mediafile.original_day, 30)
         self.assertEqual(mediafile.original_date, datetime.date(1999, 12, 30))
 
+    def test_r128_gain_stored_as_q8_number(self):
+        def round_trip(x):
+            q_num = round(x * pow(2, 8))
+            return q_num / pow(2, 8)
+
+        mediafile = self._mediafile_fixture('full')
+
+        track = -1.1
+        self.assertNotEqual(track, round_trip(track))
+        mediafile.r128_track_gain = track
+        self.assertEqual(mediafile.r128_track_gain, round_trip(track))
+
+        album = 4.2
+        self.assertNotEqual(album, round_trip(album))
+        mediafile.r128_album_gain = album
+        self.assertEqual(mediafile.r128_album_gain, round_trip(album))
+
     def test_write_packed(self):
         mediafile = self._mediafile_fixture('empty')
 


### PR DESCRIPTION
Save the value in R128_{TRACK,ALBUM}_GAIN tags not as a decimal float but as a
Q7.8 number as demanded by IETF RFC 7845, 5.3.1.

This implementation actually saves a Q8 number, i.e. does not check if the
integer part fits into 7 bits. While reading this is clearly the most sensible
approach. We could consider adding a check when writing and issuing either a
Warning or an Error.

See also [beets #3311](https://github.com/beetbox/beets/issues/3311).