### PR TITLE
Add releasegroupdisambig MediaField

### DIFF
--- a/mediafile.py
+++ b/mediafile.py
@@ -1843,6 +1843,13 @@ class MediaFile(object):
         StorageStyle('MUSICBRAINZ_ALBUMCOMMENT'),
         ASFStorageStyle('MusicBrainz/Album Comment'),
     )
+    releasegroupdisambig = MediaField(
+        # This tag mapping was invented for beets (not used by Picard, etc).
+        MP3DescStorageStyle(u'MusicBrainz Release Group Comment'),
+        MP4StorageStyle('----:com.apple.iTunes:MusicBrainz Release Group Comment'),
+        StorageStyle('MUSICBRAINZ_RELEASEGROUPCOMMENT'),
+        ASFStorageStyle('MusicBrainz/Release Group Comment'),
+    )
 
     # Release date.
     date = DateField(


### PR DESCRIPTION
As [discussed in the forum](https://discourse.beets.io/t/tag-for-releasegroupdisambig/939), add a proposed `releasegroupdisambig` ("MusicBrainz Release Group Comment") media field.