### PR TITLE
Check for real bitdepth value in AIFFTest.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
 
     install_requires=[
         'six>=1.9',
-        'mutagen>=1.33',
+        'mutagen>=1.43',
     ] + (['enum34>=1.0.4'] if sys.version_info < (3, 4, 0) else []),
 
     tests_require=[

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -930,7 +930,7 @@ class AIFFTest(ReadWriteTestBase, unittest.TestCase):
         'bitrate': 705600,
         'format': u'AIFF',
         'samplerate': 44100,
-        'bitdepth': 0,
+        'bitdepth': 16,
         'channels': 1,
     }
 


### PR DESCRIPTION
Mutagen used to not provide this information, now it does, so let's bump the dependency and check for it.

Closes #24 and addresses #23.