### PR TITLE
Add RELEASETYPE mapping for albumtype and RELEASESTATUS mapping for albumstatus

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,6 +104,7 @@ v0.4.0
 ''''''
 
 - Added a ``barcode`` field.
+- Added new tag mappings for ``albumtype`` and ``albumstatus``.
 
 v0.3.0
 ''''''

--- a/mediafile.py
+++ b/mediafile.py
@@ -1756,6 +1756,7 @@ class MediaFile(object):
     albumtype = MediaField(
         MP3DescStorageStyle(u'MusicBrainz Album Type'),
         MP4StorageStyle('----:com.apple.iTunes:MusicBrainz Album Type'),
+        StorageStyle('RELEASETYPE'),
         StorageStyle('MUSICBRAINZ_ALBUMTYPE'),
         ASFStorageStyle('MusicBrainz/Album Type'),
     )
@@ -1833,6 +1834,7 @@ class MediaFile(object):
     albumstatus = MediaField(
         MP3DescStorageStyle(u'MusicBrainz Album Status'),
         MP4StorageStyle('----:com.apple.iTunes:MusicBrainz Album Status'),
+        StorageStyle('RELEASESTATUS'),
         StorageStyle('MUSICBRAINZ_ALBUMSTATUS'),
         ASFStorageStyle('MusicBrainz/Album Status'),
     )


### PR DESCRIPTION
According to [the Picard tag mappings documentation](https://picard.musicbrainz.org/docs/mappings/), the "Release Status" tag is mapped to `MUSICBRAINZ_ALBUMSTATUS` for APEv2 and `RELEASESTATUS` for Vorbis comments and the "Release Type" tag is mapped to `MUSICBRAINZ_ALBUMTYPE` for APEv2 and `RELEASETYPE` for Vorbis comments.

Currently, mediafile only reads and writes `MUSICBRAINZ_ALBUMSTATUS` in `albumstatus` for Vorbis comments and APEv2, so it doesn't pick up the value in FLAC files edited with Picard.

Same thing for `albumtype`, `RELEASETYPE` should be supported alongside `MUSICBRAINZ_ALBUMTYPE`.