### PR TITLE
Define the minimum value of SoundCheck gain.

### DIFF
--- a/mediafile.py
+++ b/mediafile.py
@@ -290,11 +290,11 @@ def _sc_encode(gain, peak):
     # SoundCheck stores absolute RMS values in some unknown units rather
     # than the dB values RG uses. We can calculate these absolute values
     # from the gain ratio using a reference value of 1000 units. We also
-    # enforce the maximum value here, which is equivalent to about
-    # -18.2dB.
-    g1 = int(min(round((10 ** (gain / -10)) * 1000), 65534))
+    # enforce the maximum and minimum value here, which is equivalent to
+    # about -18.2dB and 30.0dB.
+    g1 = int(min(round((10 ** (gain / -10)) * 1000), 65534)) or 1
     # Same as above, except our reference level is 2500 units.
-    g2 = int(min(round((10 ** (gain / -10)) * 2500), 65534))
+    g2 = int(min(round((10 ** (gain / -10)) * 2500), 65534)) or 1
 
     # The purpose of these values are unknown, but they also seem to be
     # unused so we just use zero.

--- a/test/test_mediafile_edge.py
+++ b/test/test_mediafile_edge.py
@@ -333,6 +333,12 @@ class SoundCheckTest(unittest.TestCase):
         self.assertEqual(gain, 0.0)
         self.assertEqual(peak, 0.0)
 
+    def test_encode_excessive_gain(self):
+        # The mimimum value of SoundCheck gain is 30.0dB.
+        data = mediafile._sc_encode(60.0, 1.0)
+        gain, _ = mediafile._sc_decode(data)
+        self.assertEqual(gain, 30.0)
+
 
 class ID3v23Test(unittest.TestCase, _common.TempDirMixin):
     def _make_test(self, ext=b'mp3', id3v23=False):


### PR DESCRIPTION
`mediafile._sc_encode` had a issue that the value of SoundCheck gain going to 0 when the input gain is extremely large.
I've added a minimum to prevent this problem, so please check it out.