### PR TITLE
Fix docs to reflect None return if tag does not exist.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,10 +9,8 @@ of tags.
 It currently supports MP3 files (ID3 tags), AAC files (as tagged by iTunes) as
 well as FLAC, Ogg, Monkey's Audio, WavPack, and Musepack.
 
-MediaFile attempts to always return a usable value (i.e., it never returns
-``None`` or throws an exception when a tag is accessed). If a tag is not
-present, an empty and false value of the appropriate type -- such as zero or
-the empty string -- is returned.
+If a tag does not exist, MediaFile will return ``None`` instead of throwing
+an exception.
 
 .. _Mutagen: https://github.com/quodlibet/mutagen
 

--- a/mediafile.py
+++ b/mediafile.py
@@ -141,10 +141,12 @@ def mutagen_call(action, path, func, *args, **kwargs):
 # Utility.
 
 def _safe_cast(out_type, val):
-    """Try to covert val to out_type but never raise an exception. If
-    the value can't be converted, then a sensible default value is
-    returned. out_type should be bool, int, or unicode; otherwise, the
-    value is just passed through.
+    """Try to covert val to out_type but never raise an exception.
+
+    If the value does not exist, return None. Or, if the value
+    can't be converted, then a sensible default value is returned.
+    out_type should be bool, int, or unicode; otherwise, the value
+    is just passed through.
     """
     if val is None:
         return None


### PR DESCRIPTION
Fixes https://github.com/beetbox/mediafile/issues/38

I _think_ this captures the actual behavior, but please correct me if I'm wrong.