### PR TITLE
Add code examples to documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,7 +98,7 @@ Internals
 Examples
 --------
 
-Add cover art to a MediaFile
+To add cover art to a MediaFile:
 
 .. code:: python
 
@@ -113,7 +113,7 @@ Add cover art to a MediaFile
     f.save()
     
 
-Copy tags from one MediaFile to another
+To copy tags from one MediaFile to another:
 
 .. code:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,6 +94,42 @@ Internals
 .. autoclass:: StorageStyle
     :members:
 
+    
+Examples
+--------
+
+Add cover art to a MediaFile
+
+.. code:: python
+
+    from mediafile import MediaFile, Image, ImageType
+
+    image_file = "cover.jpg"
+    with open(image_file, 'rb') as f:
+        cover = f.read()
+        cover = Image(data=cover, desc=u'album cover', type=ImageType.front)
+    f = MediaFile("file.mp3)
+    f.images = [cover]
+    f.save()
+    
+
+Copy tags from one MediaFile to another
+
+.. code:: python
+
+    from mediafile import MediaFile
+
+    f = MediaFile("file1.mp3")
+    g = MediaFile("file2.mp3")
+
+    for field in f.fields():
+        try:
+            setattr(g, field, getattr(f, field))
+        except:
+            pass
+
+    g.save()
+    
 
 Changelog
 ---------


### PR DESCRIPTION
For new users (like me) code examples can be very helpful in understanding a library. I added two somewhat specific examples for tasks that I needed for a project to the documentation. I pieced these together by sifting through the unit tests, so I am not sure if it is the best way to go about it. 

If you are interested I could expand this pull request a bit by adding more examples and maybe some text.