### PR TITLE
New tags: Copyright, ISRC, Artists, AlbumArtists, URL

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,10 +23,11 @@ The metadata schema is generally based on MusicBrainz' schema with similar namin
 
 * basic fields like ``title``, ``album``, ``artist`` and ``albumartist``,
 * sorting variants like ``albumartist_sort`` and ``composer_sort``,
-* identifiers like ``asin`` or ``mb_releasegroupid``,
+* plural/list variants like ``artists`` and ``albumartists``,
+* identifiers like ``asin``, ``isrc`` or ``mb_releasegroupid``,
 * dates like the release ``year``, ``month`` and ``day`` with convenience wrapper ``date``,
 * detailed metadata like ``language`` or ``media``,
-* ``lyrics``,
+* ``lyrics``, ``copyright``, ``url``
 * calculated metadata like ``bpm`` (beats per minute) and ``r128_track_gain`` (ReplayGain),
 * embedded images (e.g. album art),
 * file metadata like ``bitrate`` and ``length``.

--- a/mediafile.py
+++ b/mediafile.py
@@ -889,6 +889,29 @@ class MP3DescStorageStyle(MP3StorageStyle):
             del mutagen_file[frame.HashKey]
 
 
+class MP3ListDescStorageStyle(MP3DescStorageStyle, ListStorageStyle):
+    def __init__(self, desc=u'', key='TXXX', **kwargs):
+        super(MP3ListDescStorageStyle, self).__init__(desc=desc, key=key,
+                                                      **kwargs)
+
+    def fetch(self, mutagen_file):
+        for frame in mutagen_file.tags.getall(self.key):
+            if frame.desc.lower() == self.description.lower():
+                return frame.text
+        return []
+
+    def store(self, mutagen_file, values):
+        self.delete(mutagen_file)
+        frame = mutagen.id3.Frames[self.key](
+            desc=self.description,
+            text=values,
+            encoding=mutagen.id3.Encoding.UTF8,
+        )
+        if self.id3_lang:
+            frame.lang = self.id3_lang
+        mutagen_file.tags.add(frame)
+
+
 class MP3SlashPackStorageStyle(MP3StorageStyle):
     """Store value as part of pair that is serialized as a slash-
     separated string.

--- a/mediafile.py
+++ b/mediafile.py
@@ -897,14 +897,19 @@ class MP3DescStorageStyle(MP3StorageStyle):
 
 
 class MP3ListDescStorageStyle(MP3DescStorageStyle, ListStorageStyle):
-    def __init__(self, desc=u'', key='TXXX', **kwargs):
-        super(MP3ListDescStorageStyle, self).__init__(desc=desc, key=key,
-                                                      **kwargs)
+    def __init__(self, desc=u'', key='TXXX', split_v23=False, **kwargs):
+        self.split_v23 = split_v23
+        super(MP3ListDescStorageStyle, self).__init__(
+            desc=desc, key=key, **kwargs
+        )
 
     def fetch(self, mutagen_file):
         for frame in mutagen_file.tags.getall(self.key):
             if frame.desc.lower() == self.description.lower():
-                return frame.text
+                if mutagen_file.tags.version == (2, 3, 0) and self.split_v23:
+                    return sum([el.split('/') for el in frame.text], start=[])
+                else:
+                    return frame.text
         return []
 
     def store(self, mutagen_file, values):

--- a/mediafile.py
+++ b/mediafile.py
@@ -1666,6 +1666,12 @@ class MediaFile(object):
         StorageStyle('ARTIST'),
         ASFStorageStyle('Author'),
     )
+    artists = ListMediaField(
+        MP3ListDescStorageStyle(desc=u'ARTISTS'),
+        MP4ListStorageStyle('----:com.apple.iTunes:ARTISTS'),
+        ListStorageStyle('ARTISTS'),
+        ASFStorageStyle('WM/ARTISTS'),
+    )
     album = MediaField(
         MP3StorageStyle('TALB'),
         MP4StorageStyle('\xa9alb'),
@@ -1759,6 +1765,12 @@ class MediaFile(object):
         ASFStorageStyle('WM/Comments'),
         ASFStorageStyle('Description')
     )
+    copyright = MediaField(
+        MP3StorageStyle('TCOP'),
+        MP4StorageStyle('cprt'),
+        StorageStyle('COPYRIGHT'),
+        ASFStorageStyle('Copyright'),
+    )
     bpm = MediaField(
         MP3StorageStyle('TBPM'),
         MP4StorageStyle('tmpo', as_type=int),
@@ -1779,6 +1791,12 @@ class MediaFile(object):
         StorageStyle('ALBUM ARTIST'),
         StorageStyle('ALBUMARTIST'),
         ASFStorageStyle('WM/AlbumArtist'),
+    )
+    albumartists = ListMediaField(
+        MP3ListDescStorageStyle(desc=u'ALBUMARTISTS'),
+        MP4ListStorageStyle('----:com.apple.iTunes:ALBUMARTISTS'),
+        ListStorageStyle('ALBUMARTISTS'),
+        ASFStorageStyle('WM/AlbumArtists'),
     )
     albumtype = MediaField(
         MP3DescStorageStyle(u'MusicBrainz Album Type'),
@@ -1824,7 +1842,17 @@ class MediaFile(object):
         MP3DescStorageStyle(u'BARCODE'),
         MP4StorageStyle('----:com.apple.iTunes:BARCODE'),
         StorageStyle('BARCODE'),
+        StorageStyle('UPC', read_only=True),
+        StorageStyle('EAN/UPN', read_only=True),
+        StorageStyle('EAN', read_only=True),
+        StorageStyle('UPN', read_only=True),
         ASFStorageStyle('WM/Barcode'),
+    )
+    isrc = MediaField(
+        MP3StorageStyle(u'TSRC'),
+        MP4StorageStyle('----:com.apple.iTunes:ISRC'),
+        StorageStyle('ISRC'),
+        ASFStorageStyle('WM/ISRC'),
     )
     disctitle = MediaField(
         MP3StorageStyle('TSST'),

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -365,6 +365,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         'disctotal',
         'lyrics',
         'comments',
+        'copyright',
         'bpm',
         'comp',
         'mb_trackid',
@@ -390,6 +391,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         'asin',
         'catalognum',
         'barcode',
+        'isrc',
         'disctitle',
         'script',
         'language',
@@ -449,7 +451,11 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
     def test_read_empty(self):
         mediafile = self._mediafile_fixture('empty')
         for field in self.tag_fields:
-            self.assertIsNone(getattr(mediafile, field))
+            value = getattr(mediafile, field)
+            if isinstance(value, list):
+                assert not value
+            else:
+                self.assertIsNone(value)
 
     def test_write_empty(self):
         mediafile = self._mediafile_fixture('empty')
@@ -620,7 +626,11 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         mediafile = MediaFile(mediafile.path)
 
         for key in keys:
-            self.assertIsNone(getattr(mediafile, key))
+            value = getattr(mediafile, key)
+            if isinstance(value, list):
+                assert not value
+            else:
+                self.assertIsNone(value)
 
     def test_delete_packed_total(self):
         mediafile = self._mediafile_fixture('full')
@@ -704,6 +714,9 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
 
         for key in ['disc', 'disctotal', 'track', 'tracktotal', 'bpm']:
             tags[key] = 1
+
+        for key in ['artists', 'albumartists']:
+            tags[key] = ['multival', 'test']
 
         tags['art'] = self.jpg_data
         tags['comp'] = True
@@ -976,7 +989,8 @@ class MediaFieldTest(unittest.TestCase):
 
     def test_known_fields(self):
         fields = list(ReadWriteTestBase.tag_fields)
-        fields.extend(('encoder', 'images', 'genres', 'albumtype'))
+        fields.extend(('encoder', 'images', 'genres', 'albumtype', 'artists',
+                       'albumartists'))
         assertCountEqual(self, MediaFile.fields(), fields)
 
     def test_fields_in_readable_fields(self):

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -721,6 +721,8 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         tags['art'] = self.jpg_data
         tags['comp'] = True
 
+        tags['url'] = "https://example.com/"
+
         date = datetime.date(2001, 4, 3)
         tags['date'] = date
         tags['year'] = date.year
@@ -990,7 +992,7 @@ class MediaFieldTest(unittest.TestCase):
     def test_known_fields(self):
         fields = list(ReadWriteTestBase.tag_fields)
         fields.extend(('encoder', 'images', 'genres', 'albumtype', 'artists',
-                       'albumartists'))
+                       'albumartists', 'url'))
         assertCountEqual(self, MediaFile.fields(), fields)
 
     def test_fields_in_readable_fields(self):


### PR DESCRIPTION
Also adds additional barcode tags to read from

Sources for tag mapping:
https://picard-docs.musicbrainz.org/en/appendices/tag_mapping.html#artists
https://wiki.hydrogenaud.io/index.php?title=Tag_Mapping
https://kodi.wiki/view/Music_tagging#albumartists