### PR TITLE
More tag variants for `albumartists`

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -145,6 +145,9 @@ v0.10.0
 - The multi-valued ``albumartists`` property now refers to additional file
   tags named ``ALBUM_ARTIST`` and ``ALBUM ARTISTS`` (the ``ALBUM ARTISTS``
   is being used only for reading).
+- The ``ListMediaField`` class now doesn't concatenate multiple lists if
+  found, properties using this class now overwrite each other when
+  multiple are defined like other properties.
 
 v0.9.0
 ''''''

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -142,6 +142,9 @@ v0.10.0
   ``languages``.
 - The ``catalognum`` property now refers to additional file tags named
   ``CATALOGID`` and ``DISCOGS_CATALOG`` (but only for reading, not writing).
+- The multi-valued ``albumartists`` property now refers to additional file
+  tags named ``ALBUM_ARTIST`` and ``ALBUM ARTISTS`` (the ``ALBUM ARTISTS``
+  is being used only for reading).
 
 v0.9.0
 ''''''

--- a/mediafile.py
+++ b/mediafile.py
@@ -1909,13 +1909,22 @@ class MediaFile(object):
         MP3StorageStyle('TPE2'),
         MP4StorageStyle('aART'),
         StorageStyle('ALBUM ARTIST'),
+        StorageStyle('ALBUM_ARTIST'),
         StorageStyle('ALBUMARTIST'),
         ASFStorageStyle('WM/AlbumArtist'),
     )
     albumartists = ListMediaField(
         MP3ListDescStorageStyle(desc=u'ALBUMARTISTS'),
+        MP3ListDescStorageStyle(desc=u'ALBUM_ARTISTS'),
+        MP3ListDescStorageStyle(desc=u'ALBUM ARTISTS', read_only=True),
         MP4ListStorageStyle('----:com.apple.iTunes:ALBUMARTISTS'),
+        MP4ListStorageStyle('----:com.apple.iTunes:ALBUM_ARTISTS'),
+        MP4ListStorageStyle(
+            '----:com.apple.iTunes:ALBUM ARTISTS', read_only=True
+        ),
         ListStorageStyle('ALBUMARTISTS'),
+        ListStorageStyle('ALBUM_ARTISTS'),
+        ListStorageStyle('ALBUM ARTISTS', read_only=True),
         ASFStorageStyle('WM/AlbumArtists'),
     )
     albumtypes = ListMediaField(

--- a/mediafile.py
+++ b/mediafile.py
@@ -1312,11 +1312,12 @@ class ListMediaField(MediaField):
     Uses ``get_list`` and set_list`` methods of its ``StorageStyle``
     strategies to do the actual work.
     """
-    def __get__(self, mediafile, _):
-        values = []
+    def __get__(self, mediafile, _=None):
         for style in self.styles(mediafile.mgfile):
-            values.extend(style.get_list(mediafile.mgfile))
-        return [_safe_cast(self.out_type, value) for value in values]
+            values = style.get_list(mediafile.mgfile)
+            if values:
+                return [_safe_cast(self.out_type, value) for value in values]
+        return []
 
     def __set__(self, mediafile, values):
         for style in self.styles(mediafile.mgfile):


### PR DESCRIPTION
Some fight about tag naming in Picard is still having place: https://tickets.metabrainz.org/browse/PICARD-700
Meanwhile different software using this tag uses other variants for it.
e.g. Kodi can read `ALBUMARTISTS` and `ALBUM ARTISTS` while `jaudiotagger` is tagging files using `ALBUM_ARTISTS` tag.