### PR TITLE
Require Python 3.6+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                tox-env: [py27-test, py35-test, py36-test, py37-test,
-                          py38-test, pypy-test]
+                tox-env: [py35-test, py36-test, py37-test,
+                          py38-test, py39-test, pypy-test]
                 os: [ubuntu-latest, windows-latest]
 
                 # Only test on a couple of versions on Windows.
@@ -31,8 +31,6 @@ jobs:
 
                 # Python interpreter versions. :/
                 include:
-                    - tox-env: py27-test
-                      python: 2.7
                     - tox-env: py35-test
                       python: 3.5
                     - tox-env: py36-test
@@ -41,6 +39,8 @@ jobs:
                       python: 3.7
                     - tox-env: py38-test
                       python: 3.8
+                    - tox-env: py39-test
+                      python: 3.9
                     - tox-env: pypy-test
                       python: pypy3
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,11 @@ To copy tags from one MediaFile to another:
 Changelog
 ---------
 
+v0.8.0
+''''''
+
+- MediaFile now requires Python 3.6 or later.
+
 v0.7.0
 ''''''
 

--- a/mediafile.py
+++ b/mediafile.py
@@ -58,7 +58,7 @@ import struct
 import traceback
 
 
-__version__ = '0.7.0'
+__version__ = '0.8.0'
 __all__ = ['UnreadableFileError', 'FileTypeError', 'MediaFile']
 
 log = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,19 +10,13 @@ home-page = "https://github.com/beetbox/mediafile"
 description-file = "README.rst"
 requires = [
     "six>=1.9",
-    "mutagen>=1.43; python_version < '3.0.0'",
-    "mutagen>=1.45; python_version >= '3.0.0'",
-    "enum34>=1.0.4; python_version < '3.4.0'",
+    "mutagen>=1.45",
 ]
+requires-python = ">=3.6"
 classifiers = [
     'Topic :: Multimedia :: Sound/Audio',
     'License :: OSI Approved :: MIT License',
     'Environment :: Web Environment',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,37,38}-test, py27-flake8
+envlist = py{37,38}-test, py38-flake8
 isolated_build = True
 
 [tox:.package]
@@ -14,7 +14,6 @@ basepython = python3
 deps =
     nose
     nose-show-skipped
-    mutagen>=1.27
 
 [_flake8]
 deps =
@@ -28,12 +27,11 @@ passenv =
     NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =
     {test,cov}: {[_test]deps}
-    py{27,35}-flake8: {[_flake8]deps}
+    py{35,36,37,38,39}-flake8: {[_flake8]deps}
 commands =
     cov: nosetests --with-coverage {posargs}
-    py27-test: python -m nose {posargs}
     py3{5,6,7,8}-test: python -bb -m nose {posargs}
-    py27-flake8: flake8 --min-version 2.7 {posargs} {[_flake8]files}
     py35-flake8: flake8 --min-version 3.5 {posargs} {[_flake8]files}
     py37-flake8: flake8 --min-version 3.7 {posargs} {[_flake8]files}
     py38-flake8: flake8 --min-version 3.8 {posargs} {[_flake8]files}
+    py39-flake8: flake8 --min-version 3.8 {posargs} {[_flake8]files}


### PR DESCRIPTION
As pointed out in https://github.com/beetbox/mediafile/pull/50#issuecomment-908916050, it's time to drop Python 2 support. This updates our configuration (package declarations and CI) to require Python 3.6+.

This PR does not do the work to remove the code necessary to support Python 2: for example, removing the dependency on `six`. That can happen separately.
