### PR TITLE
Fix python <=3.7 compatibility

### DIFF
--- a/mediafile.py
+++ b/mediafile.py
@@ -949,7 +949,7 @@ class MP3ListDescStorageStyle(MP3DescStorageStyle, ListStorageStyle):
         for frame in mutagen_file.tags.getall(self.key):
             if frame.desc.lower() == self.description.lower():
                 if mutagen_file.tags.version == (2, 3, 0) and self.split_v23:
-                    return sum([el.split('/') for el in frame.text], start=[])
+                    return sum((el.split('/') for el in frame.text), [])
                 else:
                     return frame.text
         return []


### PR DESCRIPTION
sum doesn't have any keyword arguments before python 3.8

fixes #53

probably should be tagged with 0.8.1 version to fix bug ;)