### PR TITLE
Add new list fields set by MusicBrainz Picard

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,12 @@ To copy tags from one MediaFile to another:
 Changelog
 ---------
 
+v0.10.0
+''''''
+
+- Add the properties ``albumtypes``, ``catalognums`` and
+  ``languages``.
+
 v0.9.0
 ''''''
 

--- a/mediafile.py
+++ b/mediafile.py
@@ -1918,13 +1918,15 @@ class MediaFile(object):
         ListStorageStyle('ALBUMARTISTS'),
         ASFStorageStyle('WM/AlbumArtists'),
     )
-    albumtype = MediaField(
-        MP3DescStorageStyle(u'MusicBrainz Album Type'),
-        MP4StorageStyle('----:com.apple.iTunes:MusicBrainz Album Type'),
-        StorageStyle('RELEASETYPE'),
-        StorageStyle('MUSICBRAINZ_ALBUMTYPE'),
+    albumtypes = ListMediaField(
+        MP3ListDescStorageStyle('MusicBrainz Album Type', split_v23=True),
+        MP4ListStorageStyle('----:com.apple.iTunes:MusicBrainz Album Type'),
+        ListStorageStyle('RELEASETYPE'),
+        ListStorageStyle('MUSICBRAINZ_ALBUMTYPE'),
         ASFStorageStyle('MusicBrainz/Album Type'),
     )
+    albumtype = albumtypes.single_field()
+
     label = MediaField(
         MP3StorageStyle('TPUB'),
         MP4StorageStyle('----:com.apple.iTunes:LABEL'),
@@ -1952,12 +1954,14 @@ class MediaFile(object):
         StorageStyle('ASIN'),
         ASFStorageStyle('MusicBrainz/ASIN'),
     )
-    catalognum = MediaField(
-        MP3DescStorageStyle(u'CATALOGNUMBER'),
-        MP4StorageStyle('----:com.apple.iTunes:CATALOGNUMBER'),
-        StorageStyle('CATALOGNUMBER'),
+    catalognums = ListMediaField(
+        MP3ListDescStorageStyle('CATALOGNUMBER', split_v23=True),
+        MP4ListStorageStyle('----:com.apple.iTunes:CATALOGNUMBER'),
+        ListStorageStyle('CATALOGNUMBER'),
         ASFStorageStyle('WM/CatalogNo'),
     )
+    catalognum = catalognums.single_field()
+
     barcode = MediaField(
         MP3DescStorageStyle(u'BARCODE'),
         MP4StorageStyle('----:com.apple.iTunes:BARCODE'),
@@ -1993,12 +1997,14 @@ class MediaFile(object):
         StorageStyle('SCRIPT'),
         ASFStorageStyle('WM/Script'),
     )
-    language = MediaField(
-        MP3StorageStyle('TLAN'),
-        MP4StorageStyle('----:com.apple.iTunes:LANGUAGE'),
-        StorageStyle('LANGUAGE'),
+    languages = ListMediaField(
+        MP3ListStorageStyle('TLAN'),
+        MP4ListStorageStyle('----:com.apple.iTunes:LANGUAGE'),
+        ListStorageStyle('LANGUAGE'),
         ASFStorageStyle('WM/Language'),
     )
+    language = languages.single_field()
+
     country = MediaField(
         MP3DescStorageStyle(u'MusicBrainz Album Release Country'),
         MP4StorageStyle('----:com.apple.iTunes:MusicBrainz '

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -1109,7 +1109,8 @@ class MediaFieldTest(unittest.TestCase):
         fields = list(ReadWriteTestBase.tag_fields)
         fields.extend(
             ('encoder', 'images', 'genres', 'albumtype', 'artists',
-             'albumartists', 'url', 'mb_artistids', 'mb_albumartistids')
+             'albumartists', 'url', 'mb_artistids', 'mb_albumartistids',
+             'albumtypes', 'catalognums', 'languages')
         )
         assertCountEqual(self, MediaFile.fields(), fields)
 


### PR DESCRIPTION
Add support for:

* `albumtypes`

    Parse secondary album types, like https://github.com/beetbox/beets/issues/2200 but from the file tags directly.

* `catalognums`

    Releases with multiple CDs sometimes have multiple catalog numbers (for example [this release](https://musicbrainz.org/release/0af3dcfd-51b0-4cb0-87c0-cfa16a70ae71)).

* `languages`

    A work on MusicBrainz can have multiple languages, and by using `Use track relationships` in Picard they get written to the files.


Until now, the values could be retrieved with a separator for ID3v2.3 tags, but not for Vorbis tags:

```python
>>> f = MediaFile('test.mp3')
>>> f.albumtype
'album/audio drama'
>>> f = MediaFile('test.flac')
>>> f.albumtype
'album'
```

With this PR:

```python
>>> f.albumtypes
['album', 'audio drama']
>>> f.albumtype
'album'
```