### PR TITLE
Support reading differently named catalog number file tags

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,8 +135,14 @@ To copy tags from one MediaFile to another:
 Changelog
 ---------
 
+v0.11.0
+'''''''
+
+- Property ``catalognum`` now refers to additional file tags ``CATALOGID`` and
+  ``DISCOGS_CATALOG`` (read-only).
+
 v0.10.0
-''''''
+'''''''
 
 - Add the properties ``albumtypes``, ``catalognums`` and
   ``languages``.

--- a/mediafile.py
+++ b/mediafile.py
@@ -1956,9 +1956,21 @@ class MediaFile(object):
     )
     catalognums = ListMediaField(
         MP3ListDescStorageStyle('CATALOGNUMBER', split_v23=True),
+        MP3ListDescStorageStyle('CATALOGID', read_only=True),
+        MP3ListDescStorageStyle('DISCOGS_CATALOG', read_only=True),
         MP4ListStorageStyle('----:com.apple.iTunes:CATALOGNUMBER'),
+        MP4ListStorageStyle(
+            '----:com.apple.iTunes:CATALOGID', read_only=True
+        ),
+        MP4ListStorageStyle(
+            '----:com.apple.iTunes:DISCOGS_CATALOG', read_only=True
+        ),
         ListStorageStyle('CATALOGNUMBER'),
+        ListStorageStyle('CATALOGID', read_only=True),
+        ListStorageStyle('DISCOGS_CATALOG', read_only=True),
         ASFStorageStyle('WM/CatalogNo'),
+        ASFStorageStyle('CATALOGID', read_only=True),
+        ASFStorageStyle('DISCOGS_CATALOG', read_only=True),
     )
     catalognum = catalognums.single_field()
 


### PR DESCRIPTION
Eg mp3tag was using DISCOGS_CATALOG a couple of years ago and is using CATALOGID, which my current tests using a trial version of mp3tag for macOS revealed.

This feature enables beets make use of these potentially available on-disk fields when importing and having `musicbrainz.extra_fields: ['catalognum']` set.