### PR TITLE
Fix #65 (update some tests and dependencies)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 tox-env: [py36-test, py37-test, py38-test, py39-test,
-                          pypy-test]
+                          py310-test, pypy-test]
                 os: [ubuntu-latest, windows-latest]
 
                 # Only test on a couple of versions on Windows.
@@ -37,6 +37,8 @@ jobs:
                       python: 3.8
                     - tox-env: py39-test
                       python: 3.9
+                    - tox-env: py310-test
+                      python: 3.10
                     - tox-env: pypy-test
                       python: pypy3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
                     - tox-env: py310-test
                       python: '3.10'
                     - tox-env: pypy-test
-                      python: pypy3
+                      python: pypy3.9
 
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,12 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                tox-env: [py36-test, py37-test, py38-test, py39-test,
+                tox-env: [py37-test, py38-test, py39-test,
                           py310-test, pypy-test]
                 os: [ubuntu-latest, windows-latest]
 
                 # Only test on a couple of versions on Windows.
                 exclude:
-                    - os: windows-latest
-                      tox-env: py36-test
                     - os: windows-latest
                       tox-env: py37-test
                     - os: windows-latest
@@ -29,8 +27,6 @@ jobs:
 
                 # Python interpreter versions. :/
                 include:
-                    - tox-env: py36-test
-                      python: '3.6'
                     - tox-env: py37-test
                       python: '3.7'
                     - tox-env: py38-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,15 +30,15 @@ jobs:
                 # Python interpreter versions. :/
                 include:
                     - tox-env: py36-test
-                      python: 3.6
+                      python: '3.6'
                     - tox-env: py37-test
-                      python: 3.7
+                      python: '3.7'
                     - tox-env: py38-test
-                      python: 3.8
+                      python: '3.8'
                     - tox-env: py39-test
-                      python: 3.9
+                      python: '3.9'
                     - tox-env: py310-test
-                      python: 3.10
+                      python: '3.10'
                     - tox-env: pypy-test
                       python: pypy3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
                       python: pypy3.9
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v1
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python }}
             - name: Install Tox

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,12 @@ To copy tags from one MediaFile to another:
 Changelog
 ---------
 
+v0.10.1
+'''''''
+
+- Fix a test failure that arose with Mutagen 1.46.
+- Require Python 3.7 or later.
+
 v0.10.0
 '''''''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,11 @@ requires = [
     "six>=1.9",
     "mutagen>=1.46",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = [
     'Topic :: Multimedia :: Sound/Audio',
     'License :: OSI Approved :: MIT License',
     'Environment :: Web Environment',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ home-page = "https://github.com/beetbox/mediafile"
 description-file = "README.rst"
 requires = [
     "six>=1.9",
-    "mutagen>=1.45",
+    "mutagen>=1.46",
 ]
 requires-python = ">=3.6"
 classifiers = [

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -1001,7 +1001,7 @@ class WAVETest(ReadWriteTestBase, unittest.TestCase):
     extension = 'wav'
     audio_properties = {
         'length': 1.0,
-        'bitrate': 88200,
+        'bitrate': 705600,
         'bitrate_mode': '',
         'encoder_info': '',
         'encoder_settings': '',

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,7 @@ basepython = python3
 
 [_test]
 deps =
-    nose
-    nose-show-skipped
+    pytest
 
 [_flake8]
 deps =
@@ -23,14 +22,11 @@ deps =
 files = mediafile.py test setup.py
 
 [testenv]
-passenv =
-    NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =
     {test,cov}: {[_test]deps}
     py{36,37,38,39,310,311}-flake8: {[_flake8]deps}
 commands =
-    cov: nosetests --with-coverage {posargs}
-    py3{6,7,8,9,10,11}-test: python -bb -m nose {posargs}
+    py3{6,7,8,9,10,11}-test: python -bb -m pytest {posargs}
     py36-flake8: flake8 --min-version 3.6 {posargs} {[_flake8]files}
     py37-flake8: flake8 --min-version 3.7 {posargs} {[_flake8]files}
     py38-flake8: flake8 --min-version 3.8 {posargs} {[_flake8]files}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{37,38}-test, py38-flake8
+envlist = py310-test, py310-flake8
 isolated_build = True
 
 [tox:.package]
@@ -27,11 +27,13 @@ passenv =
     NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =
     {test,cov}: {[_test]deps}
-    py{36,37,38,39}-flake8: {[_flake8]deps}
+    py{36,37,38,39,310,311}-flake8: {[_flake8]deps}
 commands =
     cov: nosetests --with-coverage {posargs}
-    py3{6,7,8,9}-test: python -bb -m nose {posargs}
+    py3{6,7,8,9,10,11}-test: python -bb -m nose {posargs}
     py36-flake8: flake8 --min-version 3.6 {posargs} {[_flake8]files}
     py37-flake8: flake8 --min-version 3.7 {posargs} {[_flake8]files}
     py38-flake8: flake8 --min-version 3.8 {posargs} {[_flake8]files}
     py39-flake8: flake8 --min-version 3.9 {posargs} {[_flake8]files}
+    py310-flake8: flake8 --min-version 3.10 {posargs} {[_flake8]files}
+    py311-flake8: flake8 --min-version 3.11 {posargs} {[_flake8]files}


### PR DESCRIPTION
Mutagen recently updated its policy for calculating bitrates for WAV files in https://github.com/quodlibet/mutagen/pull/566. So we now match the new/better output, and we require the version of Mutagen that produces this output.

As an added bonus, this does a little housecleaning on our Tox and GitHub Actions configuration.