### PR TITLE
POPM (popularity meter) tag support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ v1.0.0
       Swinsian interpret tags.
 - Added ``TXXX:LABEL`` and ``TXXX:MEDIA`` tags to ``label`` and ``media``
   fields, respectively, for MP3 files.
+- Added POPM (popularity meter) tag support.
 
 v0.13.0
 -------

--- a/mediafile/__init__.py
+++ b/mediafile/__init__.py
@@ -424,7 +424,13 @@ class MediaFile:
         ASFStorageStyle("TotalDiscs"),
         out_type=int,
     )
-
+    popm = MediaField(
+        MP3StorageStyle("POPM"),
+        MP4StorageStyle("POPM", as_type=int),
+        StorageStyle("POPM"),
+        ASFStorageStyle("Popm"),
+        out_type=int,
+    )
     url = MediaField(
         MP3DescStorageStyle(key="WXXX", attr="url", multispec=False),
         MP4StorageStyle("\xa9url"),

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -1127,7 +1127,7 @@ class MediaFieldTest(unittest.TestCase):
                 "albumartists_credit",
                 "albumartists_sort",
                 "subtitle",
-                "popm"
+                "popm",
             )
         )
         self.assertCountEqual(MediaFile.fields(), fields)

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -1127,6 +1127,7 @@ class MediaFieldTest(unittest.TestCase):
                 "albumartists_credit",
                 "albumartists_sort",
                 "subtitle",
+                "popm"
             )
         )
         self.assertCountEqual(MediaFile.fields(), fields)


### PR DESCRIPTION
POPM seems to be the standard tag used for ratings across many music apps. This PR adds support for this tag.

Closes https://github.com/beetbox/mediafile/issues/23