### PR TITLE
Trial and error genre not genres dependant

### DIFF
--- a/mediafile.py
+++ b/mediafile.py
@@ -1774,8 +1774,12 @@ class MediaFile(object):
         ListStorageStyle('GENRE'),
         ASFStorageStyle('WM/Genre'),
     )
-    genre = genres.single_field()
-
+    genre = MediaField(
+        MP3StorageStyle('genre'),
+        MP4StorageStyle('\xa9gen'),
+        StorageStyle('GENRE'),
+        ASFStorageStyle('WM/Genre'),
+    )
     lyricist = MediaField(
         MP3StorageStyle('TEXT'),
         MP4StorageStyle('----:com.apple.iTunes:LYRICIST'),


### PR DESCRIPTION
Just some trial and error approach for now. Details later.

Todo: Investigate what the default name for genre tag is according to whoever invented it and if it is common to use a "genres" plural tag as well (I guess not and wonder how difficult it is to find out what is contained in a genre tag - a list or a string, ....) Investigate, investigate more....

Read this for newer tags: https://id3.org/id3v2.4.0-frames

Read maybe this for older tags:
- https://id3.org/d3v2.3.0
- https://web.archive.org/web/20161124001116/
- http://id3.org/id3v2-00
- https://id3.org/ID3v1

Links source: https://en.wikipedia.org/wiki/ID3#References