### PR TITLE
allow MP3StorageStyle.fetch() to fallback to url attribute

### DIFF
--- a/mediafile.py
+++ b/mediafile.py
@@ -767,6 +767,13 @@ class MP3StorageStyle(StorageStyle):
     def fetch(self, mutagen_file):
         try:
             return mutagen_file[self.key].text[0]
+        except AttributeError:
+            try:
+                if isinstance(mutagen_file[self.key].url, list):
+                    return mutagen_file[self.key].url[0]
+                return mutagen_file[self.key].url
+            except AttributeError:
+                return None
         except (KeyError, IndexError):
             return None
 


### PR DESCRIPTION
In the issue https://github.com/Neurrone/beets-audible/issues/71 we get a crash if the "WOAF" element does not have an "text" but an "url" attribute.
I added a fallback to also use the "url" attribute on `MP3StorageStyle.fetch()`.

But I'm not an mp3 expert at all - please double check (maybe additional changes at other places are required).