### PR TITLE
Flake to ruff

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrated to ruff
+7ff9d471b23c45b6d957e7507035af39885546ab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,20 +3,20 @@ name: Build
 on:
     push:
         branches:
-           - master
+            - master
     pull_request:
         branches:
             - master
 
 jobs:
     test:
-        name: '${{ matrix.os }}: ${{ matrix.tox-env }}'
+        name: "${{ matrix.os }}: ${{ matrix.tox-env }}"
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
             matrix:
-                tox-env: [py37-test, py38-test, py39-test,
-                          py310-test, pypy-test]
+                tox-env:
+                    [py37-test, py38-test, py39-test, py310-test, pypy-test]
                 os: [ubuntu-22.04, windows-latest]
 
                 # Only test on a couple of versions on Windows.
@@ -29,13 +29,13 @@ jobs:
                 # Python interpreter versions. :/
                 include:
                     - tox-env: py37-test
-                      python: '3.7'
+                      python: "3.7"
                     - tox-env: py38-test
-                      python: '3.8'
+                      python: "3.8"
                     - tox-env: py39-test
-                      python: '3.9'
+                      python: "3.9"
                     - tox-env: py310-test
-                      python: '3.10'
+                      python: "3.10"
                     - tox-env: pypy-test
                       python: pypy3.9
 
@@ -54,5 +54,20 @@ jobs:
         name: Style
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: TrueBrain/actions-flake8@master
+            - uses: actions/checkout@v4
+            - name: Install Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.9"
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install .[dev]
+            - name: Check style with Ruff
+              id: ruff
+              run: |
+                  ruff check --output-format=github .
+            - name: Check format with Ruff
+              id: ruff-format
+              run: |
+                  ruff format --check .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,26 +16,33 @@ jobs:
             fail-fast: false
             matrix:
                 tox-env:
-                    [py37-test, py38-test, py39-test, py310-test, pypy-test]
-                os: [ubuntu-22.04, windows-latest]
+                    [
+                        py39-test,
+                        py310-test,
+                        py311-test,
+                        py312-test,
+                        py313-test,
+                        pypy-test,
+                    ]
+                os: [ubuntu-24.04, windows-latest]
 
                 # Only test on a couple of versions on Windows.
                 exclude:
-                    - os: windows-latest
-                      tox-env: py37-test
                     - os: windows-latest
                       tox-env: pypy-test
 
                 # Python interpreter versions. :/
                 include:
-                    - tox-env: py37-test
-                      python: "3.7"
-                    - tox-env: py38-test
-                      python: "3.8"
                     - tox-env: py39-test
                       python: "3.9"
                     - tox-env: py310-test
                       python: "3.10"
+                    - tox-env: py311-test
+                      python: "3.11"
+                    - tox-env: py312-test
+                      python: "3.12"
+                    - tox-env: py313-test
+                      python: "3.13"
                     - tox-env: pypy-test
                       python: pypy3.9
 

--- a/.github/workflows/changelog_reminder.yaml
+++ b/.github/workflows/changelog_reminder.yaml
@@ -1,0 +1,33 @@
+name: Verify changelog updated
+
+on:
+    pull_request_target:
+        types:
+            - opened
+            - ready_for_review
+
+jobs:
+    check_changes:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Get all updated Python files
+              id: changed-python-files
+              uses: tj-actions/changed-files@v46
+              with:
+                  files: |
+                      **.py
+
+            - name: Check for the changelog update
+              id: changelog-update
+              uses: tj-actions/changed-files@v46
+              with:
+                  files: docs/changelog.rst
+
+            - name: Comment under the PR with a reminder
+              if: steps.changed-python-files.outputs.any_changed == 'true' && steps.changelog-update.outputs.any_changed == 'false'
+              uses: thollander/actions-comment-pull-request@v2
+              with:
+                  message: "Thank you for the PR! The changelog has not been updated, so here is a friendly reminder to check if you need to add an entry."
+                  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to mediafile
+
+
+First off, thanks for taking the time to contribute! ❤️
+
+Please follow these guidelines to ensure a smooth contribution process.
+
+## Pre-requisites
+
+- Python 3.9 or higher
+- Git
+
+## Setup the Development Environment
+
+1. Fork/Clone the repository on GitHub
+```bash
+git clone <your-fork-url>
+cd mediafile
+```
+2. Install dependencies and set up the development environment
+```bash
+pip install -e .[dev]
+```
+
+## Before submitting a Pull Request
+
+Verify that your code adheres to the project standards and conventions. Run
+ruff and pytest to ensure your code is properly formatted and all tests pass.
+
+```bash
+ruff check .
+ruff format .
+pytest .
+```

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+Upcoming
+'''''''
+- Dropped support for Python 3.7 and 3.8
+
+
 v0.13.0
 '''''''
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,110 @@
+Changelog
+---------
+
+v0.13.0
+'''''''
+
+- Add a mapping compatible with Plex and ffmpeg for the "original date"
+  fields.
+- Remove an unnecessary dependency on `six`.
+- Replace `imghdr` with `filetype` to support Python 3.13.
+
+v0.12.0
+'''''''
+
+- Add the multiple-valued properties ``artists_credit``, ``artists_sort``,
+  ``albumartists_credit``, and ``albumartists_sort``.
+
+v0.11.0
+'''''''
+
+- List-valued properties now return ``None`` instead of an empty list when the
+  underlying tags are missing altogether.
+
+v0.10.1
+'''''''
+
+- Fix a test failure that arose with Mutagen 1.46.
+- Require Python 3.7 or later.
+
+v0.10.0
+'''''''
+
+- Add the multiple-valued properties ``albumtypes``, ``catalognums`` and
+  ``languages``.
+- The ``catalognum`` property now refers to additional file tags named
+  ``CATALOGID`` and ``DISCOGS_CATALOG`` (but only for reading, not writing).
+- The multi-valued ``albumartists`` property now refers to additional file
+  tags named ``ALBUM_ARTIST`` and ``ALBUM ARTISTS``. (The latter
+  is used only for reading.)
+- The ``ListMediaField`` class now doesn't concatenate multiple lists if
+  found. The first available tag is used instead, like with other kinds of
+  fields.
+
+v0.9.0
+''''''
+
+- Add the properties ``bitrate_mode``, ``encoder_info`` and
+  ``encoder_settings``.
+
+v0.8.1
+''''''
+
+- Fix a regression in v0.8.0 that caused a crash on Python versions below 3.8.
+
+v0.8.0
+''''''
+
+- MediaFile now requires Python 3.6 or later.
+- Added support for Wave (`.wav`) files.
+
+v0.7.0
+''''''
+
+- Mutagen 1.45.0 or later is now required.
+- MediaFile can now use file-like objects (instead of just the filesystem, via
+  filenames).
+
+v0.6.0
+''''''
+
+- Enforce a minimum value for SoundCheck gain values.
+
+v0.5.0
+''''''
+
+- Refactored the distribution to use `Flit`_.
+
+.. _Flit: https://flit.readthedocs.io/
+
+v0.4.0
+''''''
+
+- Added a ``barcode`` field.
+- Added new tag mappings for ``albumtype`` and ``albumstatus``.
+
+v0.3.0
+''''''
+
+- Fixed tests for compatibility with Mutagen 1.43.
+- Fix the MPEG-4 tag mapping for the ``label`` field to use the right
+  capitalization.
+
+v0.2.0
+''''''
+
+- R128 gain tags are now stored in Q7.8 integer format, as per
+  `the relevant standard`_.
+- Added an ``mb_workid`` field.
+- The Python source distribution now includes an ``__init__.py`` file that
+  makes it easier to run the tests.
+
+.. _the relevant standard: https://tools.ietf.org/html/rfc7845.html#page-25
+
+v0.1.0
+''''''
+
+This is the first independent release of MediaFile.
+It is now synchronised with the embedded version released with `beets`_ v1.4.8.
+
+.. _beets: https://beets.io

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,9 @@ an exception.
 
 .. toctree::
    :maxdepth: 2
+   :hidden:
+
+   changelog
 
 Supported Metadata Fields
 -------------------------
@@ -131,114 +134,3 @@ To copy tags from one MediaFile to another:
 
     g.save()
 
-
-Changelog
----------
-
-v0.13.0
-'''''''
-
-- Add a mapping compatible with Plex and ffmpeg for the "original date"
-  fields.
-- Remove an unnecessary dependency on `six`.
-- Replace `imghdr` with `filetype` to support Python 3.13.
-
-v0.12.0
-'''''''
-
-- Add the multiple-valued properties ``artists_credit``, ``artists_sort``,
-  ``albumartists_credit``, and ``albumartists_sort``.
-
-v0.11.0
-'''''''
-
-- List-valued properties now return ``None`` instead of an empty list when the
-  underlying tags are missing altogether.
-
-v0.10.1
-'''''''
-
-- Fix a test failure that arose with Mutagen 1.46.
-- Require Python 3.7 or later.
-
-v0.10.0
-'''''''
-
-- Add the multiple-valued properties ``albumtypes``, ``catalognums`` and
-  ``languages``.
-- The ``catalognum`` property now refers to additional file tags named
-  ``CATALOGID`` and ``DISCOGS_CATALOG`` (but only for reading, not writing).
-- The multi-valued ``albumartists`` property now refers to additional file
-  tags named ``ALBUM_ARTIST`` and ``ALBUM ARTISTS``. (The latter
-  is used only for reading.)
-- The ``ListMediaField`` class now doesn't concatenate multiple lists if
-  found. The first available tag is used instead, like with other kinds of
-  fields.
-
-v0.9.0
-''''''
-
-- Add the properties ``bitrate_mode``, ``encoder_info`` and
-  ``encoder_settings``.
-
-v0.8.1
-''''''
-
-- Fix a regression in v0.8.0 that caused a crash on Python versions below 3.8.
-
-v0.8.0
-''''''
-
-- MediaFile now requires Python 3.6 or later.
-- Added support for Wave (`.wav`) files.
-
-v0.7.0
-''''''
-
-- Mutagen 1.45.0 or later is now required.
-- MediaFile can now use file-like objects (instead of just the filesystem, via
-  filenames).
-
-v0.6.0
-''''''
-
-- Enforce a minimum value for SoundCheck gain values.
-
-v0.5.0
-''''''
-
-- Refactored the distribution to use `Flit`_.
-
-.. _Flit: https://flit.readthedocs.io/
-
-v0.4.0
-''''''
-
-- Added a ``barcode`` field.
-- Added new tag mappings for ``albumtype`` and ``albumstatus``.
-
-v0.3.0
-''''''
-
-- Fixed tests for compatibility with Mutagen 1.43.
-- Fix the MPEG-4 tag mapping for the ``label`` field to use the right
-  capitalization.
-
-v0.2.0
-''''''
-
-- R128 gain tags are now stored in Q7.8 integer format, as per
-  `the relevant standard`_.
-- Added an ``mb_workid`` field.
-- The Python source distribution now includes an ``__init__.py`` file that
-  makes it easier to run the tests.
-
-.. _the relevant standard: https://tools.ietf.org/html/rfc7845.html#page-25
-
-v0.1.0
-''''''
-
-This is the first independent release of MediaFile.
-It is now synchronised with the embedded version released with `beets`_ v1.4.8.
-
-.. _beets: https://beets.io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,28 @@ classifiers = [
 test = [
     "tox"
 ]
+dev = [
+    "ruff",
+    "pytest"
+]
+
+[tool.ruff]
+target-version = "py39"
+include = ["mediafile.py", "test/**/*.py"]
+
+[tool.ruff.lint]
+select = [
+    "E", # pycodestyle
+    "F", # pyflakes
+    "G", # flake8-logging-format
+    "I", # isort
+    "ISC", # flake8-implicit-str-concat
+    "N", # pep8-naming
+    "W", # pycodestyle
+]
+ignore = [
+    "TC006", # no need to quote 'cast's since we use 'from __future__ import annotations'
+]
+
+[tool.ruff.format]
+quote-style = "double"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,3 @@
 verbosity=1
 logging-clear-handlers=1
 eval-attr="!=slow"
-
-[flake8]
-min-version=3.7
-# Default pyflakes errors we ignore:
-# - E241: missing whitespace after ',' (used to align visually)
-# - E221: multiple spaces before operator (used to align visually)
-# - E731: do not assign a lambda expression, use a def
-# - C901: function/method complexity
-ignore=C901,E241,E221,E731

--- a/test/_common.py
+++ b/test/_common.py
@@ -14,24 +14,23 @@
 # included in all copies or substantial portions of the Software.
 
 """Some common functionality for mediafile tests."""
+
 import os
-import tempfile
 import shutil
 import sys
-
+import tempfile
 
 # Test resources path.
-RSRC = os.path.join(os.path.dirname(__file__), 'rsrc').encode('utf8')
+RSRC = os.path.join(os.path.dirname(__file__), "rsrc").encode("utf8")
 
 # OS feature test.
-HAVE_SYMLINK = sys.platform != 'win32'
+HAVE_SYMLINK = sys.platform != "win32"
 
 
 # Convenience methods for setting up a temporary sandbox directory for tests
 # that need to interact with the filesystem.
 class TempDirMixin(object):
-    """Text mixin for creating and deleting a temporary directory.
-    """
+    """Text mixin for creating and deleting a temporary directory."""
 
     def create_temp_dir(self):
         """Create a temporary directory and assign it into `self.temp_dir`.
@@ -39,11 +38,10 @@ class TempDirMixin(object):
         """
         path = tempfile.mkdtemp()
         if not isinstance(path, bytes):
-            path = path.encode('utf8')
+            path = path.encode("utf8")
         self.temp_dir = path
 
     def remove_temp_dir(self):
-        """Delete the temporary directory created by `create_temp_dir`.
-        """
+        """Delete the temporary directory created by `create_temp_dir`."""
         if os.path.isdir(self.temp_dir):
             shutil.rmtree(self.temp_dir)

--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -16,51 +16,54 @@
 """Automatically-generated blanket testing for the MediaFile metadata
 layer.
 """
+
+import datetime
 import os
 import shutil
-import datetime
 import time
 import unittest
 
-from test import _common
-from mediafile import MediaFile, Image, \
-    ImageType, CoverArtField, UnreadableFileError
 import mutagen
+
+from mediafile import CoverArtField, Image, ImageType, MediaFile, UnreadableFileError
+from test import _common
 
 
 class ArtTestMixin(object):
-    """Test reads and writes of the ``art`` property.
-    """
+    """Test reads and writes of the ``art`` property."""
 
     @property
     def png_data(self):
         if not self._png_data:
-            image_file = os.path.join(_common.RSRC, b'image-2x3.png')
-            with open(image_file, 'rb') as f:
+            image_file = os.path.join(_common.RSRC, b"image-2x3.png")
+            with open(image_file, "rb") as f:
                 self._png_data = f.read()
         return self._png_data
+
     _png_data = None
 
     @property
     def jpg_data(self):
         if not self._jpg_data:
-            image_file = os.path.join(_common.RSRC, b'image-2x3.jpg')
-            with open(image_file, 'rb') as f:
+            image_file = os.path.join(_common.RSRC, b"image-2x3.jpg")
+            with open(image_file, "rb") as f:
                 self._jpg_data = f.read()
         return self._jpg_data
+
     _jpg_data = None
 
     @property
     def tiff_data(self):
         if not self._jpg_data:
-            image_file = os.path.join(_common.RSRC, b'image-2x3.tiff')
-            with open(image_file, 'rb') as f:
+            image_file = os.path.join(_common.RSRC, b"image-2x3.tiff")
+            with open(image_file, "rb") as f:
                 self._jpg_data = f.read()
         return self._jpg_data
+
     _jpg_data = None
 
     def test_set_png_art(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
         mediafile.art = self.png_data
         mediafile.save()
 
@@ -68,7 +71,7 @@ class ArtTestMixin(object):
         self.assertEqual(mediafile.art, self.png_data)
 
     def test_set_jpg_art(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
         mediafile.art = self.jpg_data
         mediafile.save()
 
@@ -76,7 +79,7 @@ class ArtTestMixin(object):
         self.assertEqual(mediafile.art, self.jpg_data)
 
     def test_delete_art(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
         mediafile.art = self.jpg_data
         mediafile.save()
 
@@ -99,26 +102,25 @@ class ImageStructureTestMixin(ArtTestMixin):
     """
 
     def test_read_image_structures(self):
-        mediafile = self._mediafile_fixture('image')
+        mediafile = self._mediafile_fixture("image")
 
         self.assertEqual(len(mediafile.images), 2)
 
-        image = next(i for i in mediafile.images
-                     if i.mime_type == 'image/png')
+        image = next(i for i in mediafile.images if i.mime_type == "image/png")
         self.assertEqual(image.data, self.png_data)
-        self.assertExtendedImageAttributes(image, desc=u'album cover',
-                                           type=ImageType.front)
+        self.assertExtendedImageAttributes(
+            image, desc="album cover", type=ImageType.front
+        )
 
-        image = next(i for i in mediafile.images
-                     if i.mime_type == 'image/jpeg')
+        image = next(i for i in mediafile.images if i.mime_type == "image/jpeg")
         self.assertEqual(image.data, self.jpg_data)
-        self.assertExtendedImageAttributes(image, desc=u'the artist',
-                                           type=ImageType.artist)
+        self.assertExtendedImageAttributes(
+            image, desc="the artist", type=ImageType.artist
+        )
 
     def test_set_image_structure(self):
-        mediafile = self._mediafile_fixture('empty')
-        image = Image(data=self.png_data, desc=u'album cover',
-                      type=ImageType.front)
+        mediafile = self._mediafile_fixture("empty")
+        image = Image(data=self.png_data, desc="album cover", type=ImageType.front)
         mediafile.images = [image]
         mediafile.save()
 
@@ -127,30 +129,30 @@ class ImageStructureTestMixin(ArtTestMixin):
 
         image = mediafile.images[0]
         self.assertEqual(image.data, self.png_data)
-        self.assertEqual(image.mime_type, 'image/png')
-        self.assertExtendedImageAttributes(image, desc=u'album cover',
-                                           type=ImageType.front)
+        self.assertEqual(image.mime_type, "image/png")
+        self.assertExtendedImageAttributes(
+            image, desc="album cover", type=ImageType.front
+        )
 
     def test_add_image_structure(self):
-        mediafile = self._mediafile_fixture('image')
+        mediafile = self._mediafile_fixture("image")
         self.assertEqual(len(mediafile.images), 2)
 
-        image = Image(data=self.png_data, desc=u'the composer',
-                      type=ImageType.composer)
+        image = Image(data=self.png_data, desc="the composer", type=ImageType.composer)
         mediafile.images += [image]
         mediafile.save()
 
         mediafile = MediaFile(mediafile.filename)
         self.assertEqual(len(mediafile.images), 3)
 
-        images = (i for i in mediafile.images if i.desc == u'the composer')
+        images = (i for i in mediafile.images if i.desc == "the composer")
         image = next(images, None)
         self.assertExtendedImageAttributes(
-            image, desc=u'the composer', type=ImageType.composer
+            image, desc="the composer", type=ImageType.composer
         )
 
     def test_delete_image_structures(self):
-        mediafile = self._mediafile_fixture('image')
+        mediafile = self._mediafile_fixture("image")
         self.assertEqual(len(mediafile.images), 2)
 
         del mediafile.images
@@ -160,15 +162,14 @@ class ImageStructureTestMixin(ArtTestMixin):
         self.assertIsNone(mediafile.images)
 
     def test_guess_cover(self):
-        mediafile = self._mediafile_fixture('image')
+        mediafile = self._mediafile_fixture("image")
         self.assertEqual(len(mediafile.images), 2)
         cover = CoverArtField.guess_cover_image(mediafile.images)
-        self.assertEqual(cover.desc, u'album cover')
+        self.assertEqual(cover.desc, "album cover")
         self.assertEqual(mediafile.art, cover.data)
 
     def assertExtendedImageAttributes(self, image, **kwargs):  # noqa
-        """Ignore extended image attributes in the base tests.
-        """
+        """Ignore extended image attributes in the base tests."""
         pass
 
 
@@ -184,11 +185,10 @@ class ExtendedImageStructureTestMixin(ImageStructureTestMixin):
         self.assertEqual(image.type, type)
 
     def test_add_tiff_image(self):
-        mediafile = self._mediafile_fixture('image')
+        mediafile = self._mediafile_fixture("image")
         self.assertEqual(len(mediafile.images), 2)
 
-        image = Image(data=self.tiff_data, desc=u'the composer',
-                      type=ImageType.composer)
+        image = Image(data=self.tiff_data, desc="the composer", type=ImageType.composer)
         mediafile.images += [image]
         mediafile.save()
 
@@ -196,28 +196,27 @@ class ExtendedImageStructureTestMixin(ImageStructureTestMixin):
         self.assertEqual(len(mediafile.images), 3)
 
         # WMA does not preserve the order, so we have to work around this
-        image = list(filter(lambda i: i.mime_type == 'image/tiff',
-                     mediafile.images))[0]
+        image = list(filter(lambda i: i.mime_type == "image/tiff", mediafile.images))[0]
         self.assertExtendedImageAttributes(
-            image, desc=u'the composer', type=ImageType.composer)
+            image, desc="the composer", type=ImageType.composer
+        )
 
 
 class LazySaveTestMixin(object):
-    """Mediafile should only write changes when tags have changed
-    """
+    """Mediafile should only write changes when tags have changed"""
 
-    @unittest.skip(u'not yet implemented')
+    @unittest.skip("not yet implemented")
     def test_unmodified(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         mtime = self._set_past_mtime(mediafile.filename)
         self.assertEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
         mediafile.save()
         self.assertEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
-    @unittest.skip(u'not yet implemented')
+    @unittest.skip("not yet implemented")
     def test_same_tag_value(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         mtime = self._set_past_mtime(mediafile.filename)
         self.assertEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
@@ -226,31 +225,31 @@ class LazySaveTestMixin(object):
         self.assertEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
     def test_update_same_tag_value(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         mtime = self._set_past_mtime(mediafile.filename)
         self.assertEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
-        mediafile.update({'title': mediafile.title})
+        mediafile.update({"title": mediafile.title})
         mediafile.save()
         self.assertEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
-    @unittest.skip(u'not yet implemented')
+    @unittest.skip("not yet implemented")
     def test_tag_value_change(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         mtime = self._set_past_mtime(mediafile.filename)
         self.assertEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
         mediafile.title = mediafile.title
-        mediafile.album = u'another'
+        mediafile.album = "another"
         mediafile.save()
         self.assertNotEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
     def test_update_changed_tag_value(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         mtime = self._set_past_mtime(mediafile.filename)
         self.assertEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
-        mediafile.update({'title': mediafile.title, 'album': u'another'})
+        mediafile.update({"title": mediafile.title, "album": "another"})
         mediafile.save()
         self.assertNotEqual(os.stat(mediafile.filename).st_mtime, mtime)
 
@@ -261,41 +260,39 @@ class LazySaveTestMixin(object):
 
 
 class GenreListTestMixin(object):
-    """Tests access to the ``genres`` property as a list.
-    """
+    """Tests access to the ``genres`` property as a list."""
 
     def test_read_genre_list(self):
-        mediafile = self._mediafile_fixture('full')
-        self.assertCountEqual(mediafile.genres, ['the genre'])
+        mediafile = self._mediafile_fixture("full")
+        self.assertCountEqual(mediafile.genres, ["the genre"])
 
     def test_write_genre_list(self):
-        mediafile = self._mediafile_fixture('empty')
-        mediafile.genres = [u'one', u'two']
+        mediafile = self._mediafile_fixture("empty")
+        mediafile.genres = ["one", "two"]
         mediafile.save()
 
         mediafile = MediaFile(mediafile.filename)
-        self.assertCountEqual(mediafile.genres, [u'one', u'two'])
+        self.assertCountEqual(mediafile.genres, ["one", "two"])
 
     def test_write_genre_list_get_first(self):
-        mediafile = self._mediafile_fixture('empty')
-        mediafile.genres = [u'one', u'two']
+        mediafile = self._mediafile_fixture("empty")
+        mediafile.genres = ["one", "two"]
         mediafile.save()
 
         mediafile = MediaFile(mediafile.filename)
-        self.assertEqual(mediafile.genre, u'one')
+        self.assertEqual(mediafile.genre, "one")
 
     def test_append_genre_list(self):
-        mediafile = self._mediafile_fixture('full')
-        self.assertEqual(mediafile.genre, u'the genre')
-        mediafile.genres += [u'another']
+        mediafile = self._mediafile_fixture("full")
+        self.assertEqual(mediafile.genre, "the genre")
+        mediafile.genres += ["another"]
         mediafile.save()
 
         mediafile = MediaFile(mediafile.filename)
-        self.assertCountEqual(mediafile.genres, [u'the genre', u'another'])
+        self.assertCountEqual(mediafile.genres, ["the genre", "another"])
 
 
-class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
-                        _common.TempDirMixin):
+class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin, _common.TempDirMixin):
     """Test writing and reading tags. Subclasses must set ``extension``
     and ``audio_properties``.
 
@@ -316,93 +313,93 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
     """
 
     full_initial_tags = {
-        'title':             u'full',
-        'artist':            u'the artist',
-        'album':             u'the album',
-        'genre':             u'the genre',
-        'composer':          u'the composer',
-        'grouping':          u'the grouping',
-        'year':              2001,
-        'month':             None,
-        'day':               None,
-        'date':              datetime.date(2001, 1, 1),
-        'track':             2,
-        'tracktotal':        3,
-        'disc':              4,
-        'disctotal':         5,
-        'lyrics':            u'the lyrics',
-        'comments':          u'the comments',
-        'bpm':               6,
-        'comp':              True,
-        'mb_trackid':        '8b882575-08a5-4452-a7a7-cbb8a1531f9e',
-        'mb_releasetrackid': 'c29f3a57-b439-46fd-a2e2-93776b1371e0',
-        'mb_albumid':        '9e873859-8aa4-4790-b985-5a953e8ef628',
-        'mb_artistid':       '7cf0ea9d-86b9-4dad-ba9e-2355a64899ea',
-        'art':               None,
-        'label':             u'the label',
+        "title": "full",
+        "artist": "the artist",
+        "album": "the album",
+        "genre": "the genre",
+        "composer": "the composer",
+        "grouping": "the grouping",
+        "year": 2001,
+        "month": None,
+        "day": None,
+        "date": datetime.date(2001, 1, 1),
+        "track": 2,
+        "tracktotal": 3,
+        "disc": 4,
+        "disctotal": 5,
+        "lyrics": "the lyrics",
+        "comments": "the comments",
+        "bpm": 6,
+        "comp": True,
+        "mb_trackid": "8b882575-08a5-4452-a7a7-cbb8a1531f9e",
+        "mb_releasetrackid": "c29f3a57-b439-46fd-a2e2-93776b1371e0",
+        "mb_albumid": "9e873859-8aa4-4790-b985-5a953e8ef628",
+        "mb_artistid": "7cf0ea9d-86b9-4dad-ba9e-2355a64899ea",
+        "art": None,
+        "label": "the label",
     }
 
     tag_fields = [
-        'title',
-        'artist',
-        'album',
-        'genre',
-        'lyricist',
-        'composer',
-        'composer_sort',
-        'arranger',
-        'grouping',
-        'year',
-        'month',
-        'day',
-        'date',
-        'track',
-        'tracktotal',
-        'disc',
-        'disctotal',
-        'lyrics',
-        'comments',
-        'copyright',
-        'bpm',
-        'comp',
-        'mb_trackid',
-        'mb_releasetrackid',
-        'mb_workid',
-        'mb_albumid',
-        'mb_artistid',
-        'art',
-        'label',
-        'rg_track_peak',
-        'rg_track_gain',
-        'rg_album_peak',
-        'rg_album_gain',
-        'r128_track_gain',
-        'r128_album_gain',
-        'albumartist',
-        'mb_albumartistid',
-        'artist_sort',
-        'albumartist_sort',
-        'acoustid_fingerprint',
-        'acoustid_id',
-        'mb_releasegroupid',
-        'asin',
-        'catalognum',
-        'barcode',
-        'isrc',
-        'disctitle',
-        'script',
-        'language',
-        'country',
-        'albumstatus',
-        'media',
-        'albumdisambig',
-        'artist_credit',
-        'albumartist_credit',
-        'original_year',
-        'original_month',
-        'original_day',
-        'original_date',
-        'initial_key',
+        "title",
+        "artist",
+        "album",
+        "genre",
+        "lyricist",
+        "composer",
+        "composer_sort",
+        "arranger",
+        "grouping",
+        "year",
+        "month",
+        "day",
+        "date",
+        "track",
+        "tracktotal",
+        "disc",
+        "disctotal",
+        "lyrics",
+        "comments",
+        "copyright",
+        "bpm",
+        "comp",
+        "mb_trackid",
+        "mb_releasetrackid",
+        "mb_workid",
+        "mb_albumid",
+        "mb_artistid",
+        "art",
+        "label",
+        "rg_track_peak",
+        "rg_track_gain",
+        "rg_album_peak",
+        "rg_album_gain",
+        "r128_track_gain",
+        "r128_album_gain",
+        "albumartist",
+        "mb_albumartistid",
+        "artist_sort",
+        "albumartist_sort",
+        "acoustid_fingerprint",
+        "acoustid_id",
+        "mb_releasegroupid",
+        "asin",
+        "catalognum",
+        "barcode",
+        "isrc",
+        "disctitle",
+        "script",
+        "language",
+        "country",
+        "albumstatus",
+        "media",
+        "albumdisambig",
+        "artist_credit",
+        "albumartist_credit",
+        "original_year",
+        "original_month",
+        "original_day",
+        "original_date",
+        "initial_key",
     ]
 
     def setUp(self):
@@ -412,12 +409,12 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.remove_temp_dir()
 
     def test_read_nonexisting(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         os.remove(mediafile.filename)
         self.assertRaises(UnreadableFileError, MediaFile, mediafile.filename)
 
     def test_save_nonexisting(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         os.remove(mediafile.filename)
         try:
             mediafile.save()
@@ -425,7 +422,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
             pass
 
     def test_delete_nonexisting(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         os.remove(mediafile.filename)
         try:
             mediafile.delete()
@@ -433,20 +430,19 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
             pass
 
     def test_read_audio_properties(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         for key, value in self.audio_properties.items():
             if isinstance(value, float):
-                self.assertAlmostEqual(getattr(mediafile, key), value,
-                                       delta=0.1)
+                self.assertAlmostEqual(getattr(mediafile, key), value, delta=0.1)
             else:
                 self.assertEqual(getattr(mediafile, key), value)
 
     def test_read_full(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         self.assertTags(mediafile, self.full_initial_tags)
 
     def test_read_empty(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
         for field in self.tag_fields:
             value = getattr(mediafile, field)
             if isinstance(value, list):
@@ -455,7 +451,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
                 self.assertIsNone(value)
 
     def test_write_empty(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
         tags = self._generate_tags()
 
         for key, value in tags.items():
@@ -466,7 +462,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertTags(mediafile, tags)
 
     def test_update_empty(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
         tags = self._generate_tags()
 
         mediafile.update(tags)
@@ -476,7 +472,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertTags(mediafile, tags)
 
     def test_overwrite_full(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         tags = self._generate_tags()
 
         for key, value in tags.items():
@@ -492,7 +488,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertTags(mediafile, tags)
 
     def test_update_full(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         tags = self._generate_tags()
 
         mediafile.update(tags)
@@ -505,7 +501,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertTags(mediafile, tags)
 
     def test_write_date_components(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         mediafile.year = 2001
         mediafile.month = 1
         mediafile.day = 2
@@ -525,7 +521,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertEqual(mediafile.original_date, datetime.date(1999, 12, 30))
 
     def test_write_incomplete_date_components(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
         mediafile.year = 2001
         mediafile.month = None
         mediafile.day = 2
@@ -538,7 +534,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertEqual(mediafile.date, datetime.date(2001, 1, 1))
 
     def test_write_dates(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         mediafile.date = datetime.date(2001, 1, 2)
         mediafile.original_date = datetime.date(1999, 12, 30)
         mediafile.save()
@@ -558,7 +554,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
             q_num = round(x * pow(2, 8))
             return q_num / pow(2, 8)
 
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
 
         track = -1.1
         self.assertNotEqual(track, round_trip(track))
@@ -571,7 +567,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertEqual(mediafile.r128_album_gain, round_trip(album))
 
     def test_write_packed(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
 
         mediafile.tracktotal = 2
         mediafile.track = 1
@@ -582,16 +578,16 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertEqual(mediafile.tracktotal, 2)
 
     def test_write_counters_without_total(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         self.assertEqual(mediafile.track, 2)
         self.assertEqual(mediafile.tracktotal, 3)
         self.assertEqual(mediafile.disc, 4)
         self.assertEqual(mediafile.disctotal, 5)
 
         mediafile.track = 10
-        delattr(mediafile, 'tracktotal')
+        delattr(mediafile, "tracktotal")
         mediafile.disc = 10
-        delattr(mediafile, 'disctotal')
+        delattr(mediafile, "disctotal")
         mediafile.save()
 
         mediafile = MediaFile(mediafile.filename)
@@ -604,7 +600,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         """The `unparseable.*` fixture should not crash but should return None
         for all parts of the release date.
         """
-        mediafile = self._mediafile_fixture('unparseable')
+        mediafile = self._mediafile_fixture("unparseable")
 
         self.assertIsNone(mediafile.date)
         self.assertIsNone(mediafile.year)
@@ -612,10 +608,10 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertIsNone(mediafile.day)
 
     def test_delete_tag(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
 
         keys = self.full_initial_tags.keys()
-        for key in set(keys) - set(['art', 'month', 'day']):
+        for key in set(keys) - set(["art", "month", "day"]):
             self.assertIsNotNone(getattr(mediafile, key))
         for key in keys:
             delattr(mediafile, key)
@@ -630,18 +626,18 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
                 self.assertIsNone(value)
 
     def test_delete_packed_total(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
 
-        delattr(mediafile, 'tracktotal')
-        delattr(mediafile, 'disctotal')
+        delattr(mediafile, "tracktotal")
+        delattr(mediafile, "disctotal")
 
         mediafile.save()
         mediafile = MediaFile(mediafile.filename)
-        self.assertEqual(mediafile.track, self.full_initial_tags['track'])
-        self.assertEqual(mediafile.disc, self.full_initial_tags['disc'])
+        self.assertEqual(mediafile.track, self.full_initial_tags["track"])
+        self.assertEqual(mediafile.disc, self.full_initial_tags["disc"])
 
     def test_delete_partial_date(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
 
         mediafile.date = datetime.date(2001, 12, 3)
         mediafile.save()
@@ -651,7 +647,7 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertIsNotNone(mediafile.month)
         self.assertIsNotNone(mediafile.day)
 
-        delattr(mediafile, 'month')
+        delattr(mediafile, "month")
         mediafile.save()
         mediafile = MediaFile(mediafile.filename)
         self.assertIsNotNone(mediafile.date)
@@ -660,12 +656,12 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
         self.assertIsNone(mediafile.day)
 
     def test_delete_year(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
 
         self.assertIsNotNone(mediafile.date)
         self.assertIsNotNone(mediafile.year)
 
-        delattr(mediafile, 'year')
+        delattr(mediafile, "year")
         mediafile.save()
         mediafile = MediaFile(mediafile.filename)
         self.assertIsNone(mediafile.date)
@@ -677,133 +673,140 @@ class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin,
             try:
                 value2 = getattr(mediafile, key)
             except AttributeError:
-                errors.append(u'Tag %s does not exist' % key)
+                errors.append("Tag %s does not exist" % key)
             else:
                 if value2 != value:
-                    errors.append(u'Tag %s: %r != %r' % (key, value2, value))
+                    errors.append("Tag %s: %r != %r" % (key, value2, value))
         if any(errors):
-            errors = [u'Tags did not match'] + errors
-            self.fail('\n  '.join(errors))
+            errors = ["Tags did not match"] + errors
+            self.fail("\n  ".join(errors))
 
     def _mediafile_fixture(self, name):
-        name = name + '.' + self.extension
+        name = name + "." + self.extension
         if not isinstance(name, bytes):
-            name = name.encode('utf8')
+            name = name.encode("utf8")
         src = os.path.join(_common.RSRC, name)
         target = os.path.join(self.temp_dir, name)
         shutil.copy(src, target)
         return MediaFile(target)
 
     def _generate_tags(self, base=None):
-        """Return dictionary of tags, mapping tag names to values.
-        """
+        """Return dictionary of tags, mapping tag names to values."""
         tags = {}
 
         for key in self.tag_fields:
-            if key.startswith('rg_'):
+            if key.startswith("rg_"):
                 # ReplayGain is float
                 tags[key] = 1.0
-            elif key.startswith('r128_'):
+            elif key.startswith("r128_"):
                 # R128 is int
                 tags[key] = -1
             else:
-                tags[key] = 'value\u2010%s' % key
+                tags[key] = "value\u2010%s" % key
 
-        for key in ['disc', 'disctotal', 'track', 'tracktotal', 'bpm']:
+        for key in ["disc", "disctotal", "track", "tracktotal", "bpm"]:
             tags[key] = 1
 
         for key in [
-            'artists', 'albumartists', 'artists_credit',
-            'albumartists_credit', 'artists_sort', 'albumartists_sort'
+            "artists",
+            "albumartists",
+            "artists_credit",
+            "albumartists_credit",
+            "artists_sort",
+            "albumartists_sort",
         ]:
-            tags[key] = ['multival', 'test']
+            tags[key] = ["multival", "test"]
 
-        tags['art'] = self.jpg_data
-        tags['comp'] = True
+        tags["art"] = self.jpg_data
+        tags["comp"] = True
 
-        tags['url'] = "https://example.com/"
+        tags["url"] = "https://example.com/"
 
         date = datetime.date(2001, 4, 3)
-        tags['date'] = date
-        tags['year'] = date.year
-        tags['month'] = date.month
-        tags['day'] = date.day
+        tags["date"] = date
+        tags["year"] = date.year
+        tags["month"] = date.month
+        tags["day"] = date.day
 
         original_date = datetime.date(1999, 5, 6)
-        tags['original_date'] = original_date
-        tags['original_year'] = original_date.year
-        tags['original_month'] = original_date.month
-        tags['original_day'] = original_date.day
+        tags["original_date"] = original_date
+        tags["original_year"] = original_date.year
+        tags["original_month"] = original_date.month
+        tags["original_day"] = original_date.day
 
         return tags
 
 
 class PartialTestMixin(object):
     tags_without_total = {
-        'track':      2,
-        'tracktotal': 0,
-        'disc':       4,
-        'disctotal':  0,
+        "track": 2,
+        "tracktotal": 0,
+        "disc": 4,
+        "disctotal": 0,
     }
 
     def test_read_track_without_total(self):
-        mediafile = self._mediafile_fixture('partial')
+        mediafile = self._mediafile_fixture("partial")
         self.assertEqual(mediafile.track, 2)
         self.assertIsNone(mediafile.tracktotal)
         self.assertEqual(mediafile.disc, 4)
         self.assertIsNone(mediafile.disctotal)
 
 
-class MP3Test(ReadWriteTestBase, PartialTestMixin,
-              ExtendedImageStructureTestMixin,
-              unittest.TestCase):
-    extension = 'mp3'
+class MP3Test(
+    ReadWriteTestBase,
+    PartialTestMixin,
+    ExtendedImageStructureTestMixin,
+    unittest.TestCase,
+):
+    extension = "mp3"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 80000,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': 'MP3',
-        'samplerate': 44100,
-        'bitdepth': 0,
-        'channels': 1,
+        "length": 1.0,
+        "bitrate": 80000,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "MP3",
+        "samplerate": 44100,
+        "bitdepth": 0,
+        "channels": 1,
     }
 
     def test_unknown_apic_type(self):
-        mediafile = self._mediafile_fixture('image_unknown_type')
+        mediafile = self._mediafile_fixture("image_unknown_type")
         self.assertEqual(mediafile.images[0].type, ImageType.other)
 
     def test_bitrate_mode(self):
-        mediafile = self._mediafile_fixture('cbr')
-        self.assertEqual(mediafile.bitrate_mode, 'CBR')
+        mediafile = self._mediafile_fixture("cbr")
+        self.assertEqual(mediafile.bitrate_mode, "CBR")
 
     def test_encoder_info(self):
-        mediafile = self._mediafile_fixture('cbr')
-        self.assertEqual(mediafile.encoder_info, 'LAME 3.100.0+')
+        mediafile = self._mediafile_fixture("cbr")
+        self.assertEqual(mediafile.encoder_info, "LAME 3.100.0+")
 
     def test_encoder_settings(self):
-        mediafile = self._mediafile_fixture('cbr')
-        self.assertEqual(mediafile.encoder_settings, '-b 80')
+        mediafile = self._mediafile_fixture("cbr")
+        self.assertEqual(mediafile.encoder_settings, "-b 80")
 
 
-class MP4Test(ReadWriteTestBase, PartialTestMixin,
-              ImageStructureTestMixin, unittest.TestCase):
-    extension = 'm4a'
+class MP4Test(
+    ReadWriteTestBase, PartialTestMixin, ImageStructureTestMixin, unittest.TestCase
+):
+    extension = "m4a"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 64000,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': 'AAC',
-        'samplerate': 44100,
-        'bitdepth': 16,
-        'channels': 2,
+        "length": 1.0,
+        "bitrate": 64000,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "AAC",
+        "samplerate": 44100,
+        "bitdepth": 16,
+        "channels": 2,
     }
 
     def test_add_tiff_image_fails(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
         with self.assertRaises(ValueError):
             mediafile.images = [Image(data=self.tiff_data)]
 
@@ -813,223 +816,223 @@ class MP4Test(ReadWriteTestBase, PartialTestMixin,
 
 
 class AlacTest(ReadWriteTestBase, unittest.TestCase):
-    extension = 'alac.m4a'
+    extension = "alac.m4a"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 21830,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
+        "length": 1.0,
+        "bitrate": 21830,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
         # 'format': 'ALAC',
-        'samplerate': 44100,
-        'bitdepth': 16,
-        'channels': 1,
+        "samplerate": 44100,
+        "bitdepth": 16,
+        "channels": 1,
     }
 
 
 class MusepackTest(ReadWriteTestBase, unittest.TestCase):
-    extension = 'mpc'
+    extension = "mpc"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 24023,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'Musepack',
-        'samplerate': 44100,
-        'bitdepth': 0,
-        'channels': 2,
+        "length": 1.0,
+        "bitrate": 24023,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "Musepack",
+        "samplerate": 44100,
+        "bitdepth": 0,
+        "channels": 2,
     }
 
 
-class WMATest(ReadWriteTestBase, ExtendedImageStructureTestMixin,
-              unittest.TestCase):
-    extension = 'wma'
+class WMATest(ReadWriteTestBase, ExtendedImageStructureTestMixin, unittest.TestCase):
+    extension = "wma"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 128000,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'Windows Media',
-        'samplerate': 44100,
-        'bitdepth': 0,
-        'channels': 1,
+        "length": 1.0,
+        "bitrate": 128000,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "Windows Media",
+        "samplerate": 44100,
+        "bitdepth": 0,
+        "channels": 1,
     }
 
     def test_write_genre_list_get_first(self):
         # WMA does not preserve list order
-        mediafile = self._mediafile_fixture('empty')
-        mediafile.genres = [u'one', u'two']
+        mediafile = self._mediafile_fixture("empty")
+        mediafile.genres = ["one", "two"]
         mediafile.save()
 
         mediafile = MediaFile(mediafile.filename)
-        self.assertIn(mediafile.genre, [u'one', u'two'])
+        self.assertIn(mediafile.genre, ["one", "two"])
 
     def test_read_pure_tags(self):
-        mediafile = self._mediafile_fixture('pure')
-        self.assertEqual(mediafile.comments, u'the comments')
-        self.assertEqual(mediafile.title, u'the title')
-        self.assertEqual(mediafile.artist, u'the artist')
+        mediafile = self._mediafile_fixture("pure")
+        self.assertEqual(mediafile.comments, "the comments")
+        self.assertEqual(mediafile.title, "the title")
+        self.assertEqual(mediafile.artist, "the artist")
 
 
-class OggTest(ReadWriteTestBase, ExtendedImageStructureTestMixin,
-              unittest.TestCase):
-    extension = 'ogg'
+class OggTest(ReadWriteTestBase, ExtendedImageStructureTestMixin, unittest.TestCase):
+    extension = "ogg"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 48000,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'OGG',
-        'samplerate': 44100,
-        'bitdepth': 0,
-        'channels': 1,
+        "length": 1.0,
+        "bitrate": 48000,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "OGG",
+        "samplerate": 44100,
+        "bitdepth": 0,
+        "channels": 1,
     }
 
     def test_read_date_from_year_tag(self):
-        mediafile = self._mediafile_fixture('year')
+        mediafile = self._mediafile_fixture("year")
         self.assertEqual(mediafile.year, 2000)
         self.assertEqual(mediafile.date, datetime.date(2000, 1, 1))
 
     def test_write_date_to_year_tag(self):
-        mediafile = self._mediafile_fixture('empty')
+        mediafile = self._mediafile_fixture("empty")
         mediafile.year = 2000
         mediafile.save()
 
         mediafile = MediaFile(mediafile.filename)
-        self.assertEqual(mediafile.mgfile['YEAR'], [u'2000'])
+        self.assertEqual(mediafile.mgfile["YEAR"], ["2000"])
 
     def test_legacy_coverart_tag(self):
-        mediafile = self._mediafile_fixture('coverart')
-        self.assertTrue('coverart' in mediafile.mgfile)
+        mediafile = self._mediafile_fixture("coverart")
+        self.assertTrue("coverart" in mediafile.mgfile)
         self.assertEqual(mediafile.art, self.png_data)
 
         mediafile.art = self.png_data
         mediafile.save()
 
         mediafile = MediaFile(mediafile.filename)
-        self.assertFalse('coverart' in mediafile.mgfile)
+        self.assertFalse("coverart" in mediafile.mgfile)
 
     def test_date_tag_with_slashes(self):
-        mediafile = self._mediafile_fixture('date_with_slashes')
+        mediafile = self._mediafile_fixture("date_with_slashes")
         self.assertEqual(mediafile.year, 2005)
         self.assertEqual(mediafile.month, 6)
         self.assertEqual(mediafile.day, 5)
 
 
-class FlacTest(ReadWriteTestBase, PartialTestMixin,
-               ExtendedImageStructureTestMixin,
-               unittest.TestCase):
-    extension = 'flac'
+class FlacTest(
+    ReadWriteTestBase,
+    PartialTestMixin,
+    ExtendedImageStructureTestMixin,
+    unittest.TestCase,
+):
+    extension = "flac"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 108688,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'FLAC',
-        'samplerate': 44100,
-        'bitdepth': 16,
-        'channels': 1,
+        "length": 1.0,
+        "bitrate": 108688,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "FLAC",
+        "samplerate": 44100,
+        "bitdepth": 16,
+        "channels": 1,
     }
 
 
-class ApeTest(ReadWriteTestBase, ExtendedImageStructureTestMixin,
-              unittest.TestCase):
-    extension = 'ape'
+class ApeTest(ReadWriteTestBase, ExtendedImageStructureTestMixin, unittest.TestCase):
+    extension = "ape"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 112608,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'APE',
-        'samplerate': 44100,
-        'bitdepth': 16,
-        'channels': 1,
+        "length": 1.0,
+        "bitrate": 112608,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "APE",
+        "samplerate": 44100,
+        "bitdepth": 16,
+        "channels": 1,
     }
 
 
 class WavpackTest(ReadWriteTestBase, unittest.TestCase):
-    extension = 'wv'
+    extension = "wv"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 109312,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'WavPack',
-        'samplerate': 44100,
-        'bitdepth': 16 if mutagen.version >= (1, 45, 0) else 0,
-        'channels': 1,
+        "length": 1.0,
+        "bitrate": 109312,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "WavPack",
+        "samplerate": 44100,
+        "bitdepth": 16 if mutagen.version >= (1, 45, 0) else 0,
+        "channels": 1,
     }
 
 
 class OpusTest(ReadWriteTestBase, unittest.TestCase):
-    extension = 'opus'
+    extension = "opus"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 66792,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'Opus',
-        'samplerate': 48000,
-        'bitdepth': 0,
-        'channels': 1,
+        "length": 1.0,
+        "bitrate": 66792,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "Opus",
+        "samplerate": 48000,
+        "bitdepth": 0,
+        "channels": 1,
     }
 
 
 class AIFFTest(ReadWriteTestBase, unittest.TestCase):
-    extension = 'aiff'
+    extension = "aiff"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 705600,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'AIFF',
-        'samplerate': 44100,
-        'bitdepth': 16,
-        'channels': 1,
+        "length": 1.0,
+        "bitrate": 705600,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "AIFF",
+        "samplerate": 44100,
+        "bitdepth": 16,
+        "channels": 1,
     }
 
 
 class WAVETest(ReadWriteTestBase, unittest.TestCase):
-    extension = 'wav'
+    extension = "wav"
     audio_properties = {
-        'length': 1.0,
-        'bitrate': 705600,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'WAVE',
-        'samplerate': 44100,
-        'bitdepth': 16,
-        'channels': 1,
+        "length": 1.0,
+        "bitrate": 705600,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "WAVE",
+        "samplerate": 44100,
+        "bitdepth": 16,
+        "channels": 1,
     }
 
     full_initial_tags = {
-        'title':             u'full',
-        'artist':            u'the artist',
-        'album':             u'the album',
-        'genre':             u'the genre',
-        'track':             2,
-        'tracktotal':        3,
+        "title": "full",
+        "artist": "the artist",
+        "album": "the album",
+        "genre": "the genre",
+        "track": 2,
+        "tracktotal": 3,
     }
 
     tag_fields = [
-        'title',
-        'artist',
-        'album',
-        'genre',
-        'track',
-        'original_year',
-        'original_month',
-        'original_day',
-        'original_date',
+        "title",
+        "artist",
+        "album",
+        "genre",
+        "track",
+        "original_year",
+        "original_month",
+        "original_day",
+        "original_date",
     ]
 
     # Only a small subset of fields are supported by LIST/INFO
@@ -1039,30 +1042,30 @@ class WAVETest(ReadWriteTestBase, unittest.TestCase):
 
     # Missing fields: disc, disctotal
     def test_write_counters_without_total(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
         self.assertEqual(mediafile.track, 2)
         self.assertEqual(mediafile.tracktotal, 3)
 
     # Missing fields: date, year
     def test_delete_year(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
 
         self.assertIsNotNone(mediafile.original_year)
 
-        delattr(mediafile, 'original_year')
+        delattr(mediafile, "original_year")
         mediafile.save()
         mediafile = MediaFile(mediafile.filename)
         self.assertIsNone(mediafile.original_year)
 
     # Missing fields:  disctotal
     def test_delete_packed_total(self):
-        mediafile = self._mediafile_fixture('full')
+        mediafile = self._mediafile_fixture("full")
 
-        delattr(mediafile, 'tracktotal')
+        delattr(mediafile, "tracktotal")
 
         mediafile.save()
         mediafile = MediaFile(mediafile.filename)
-        self.assertEqual(mediafile.track, self.full_initial_tags['track'])
+        self.assertEqual(mediafile.track, self.full_initial_tags["track"])
 
 
 # Check whether we have a Mutagen version with DSF support. We can
@@ -1077,30 +1080,29 @@ else:
 
 @unittest.skipIf(not HAVE_DSF, "Mutagen does not have DSF support")
 class DSFTest(ReadWriteTestBase, unittest.TestCase):
-    extension = 'dsf'
+    extension = "dsf"
     audio_properties = {
-        'length': 0.01,
-        'bitrate': 11289600,
-        'bitrate_mode': '',
-        'encoder_info': '',
-        'encoder_settings': '',
-        'format': u'DSD Stream File',
-        'samplerate': 5644800,
-        'bitdepth': 1,
-        'channels': 2,
+        "length": 0.01,
+        "bitrate": 11289600,
+        "bitrate_mode": "",
+        "encoder_info": "",
+        "encoder_settings": "",
+        "format": "DSD Stream File",
+        "samplerate": 5644800,
+        "bitdepth": 1,
+        "channels": 2,
     }
 
 
 class MediaFieldTest(unittest.TestCase):
-
     def test_properties_from_fields(self):
-        path = os.path.join(_common.RSRC, b'full.mp3')
+        path = os.path.join(_common.RSRC, b"full.mp3")
         mediafile = MediaFile(path)
         for field in MediaFile.fields():
             self.assertTrue(hasattr(mediafile, field))
 
     def test_properties_from_readable_fields(self):
-        path = os.path.join(_common.RSRC, b'full.mp3')
+        path = os.path.join(_common.RSRC, b"full.mp3")
         mediafile = MediaFile(path)
         for field in MediaFile.readable_fields():
             self.assertTrue(hasattr(mediafile, field))
@@ -1108,11 +1110,25 @@ class MediaFieldTest(unittest.TestCase):
     def test_known_fields(self):
         fields = list(ReadWriteTestBase.tag_fields)
         fields.extend(
-            ('encoder', 'images', 'genres', 'albumtype', 'artists',
-             'albumartists', 'url', 'mb_artistids', 'mb_albumartistids',
-             'albumtypes', 'catalognums', 'languages', 'artists_credit',
-             'artists_sort', 'albumartists_credit', 'albumartists_sort',
-             'subtitle')
+            (
+                "encoder",
+                "images",
+                "genres",
+                "albumtype",
+                "artists",
+                "albumartists",
+                "url",
+                "mb_artistids",
+                "mb_albumartistids",
+                "albumtypes",
+                "catalognums",
+                "languages",
+                "artists_credit",
+                "artists_sort",
+                "albumartists_credit",
+                "albumartists_sort",
+                "subtitle",
+            )
         )
         self.assertCountEqual(MediaFile.fields(), fields)
 
@@ -1126,5 +1142,5 @@ def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_mediafile_edge.py
+++ b/test/test_mediafile_edge.py
@@ -13,17 +13,16 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Specific, edge-case tests for the MediaFile metadata layer.
-"""
+"""Specific, edge-case tests for the MediaFile metadata layer."""
+
 import os
 import shutil
 import unittest
+
 import mutagen.id3
 
-from test import _common
-
 import mediafile
-
+from test import _common
 
 _sc = mediafile._safe_cast
 
@@ -33,18 +32,14 @@ class EdgeTest(unittest.TestCase):
         # Some files have an ID3 frame that has a list with no elements.
         # This is very hard to produce, so this is just the first 8192
         # bytes of a file found "in the wild".
-        emptylist = mediafile.MediaFile(
-            os.path.join(_common.RSRC, b'emptylist.mp3')
-        )
+        emptylist = mediafile.MediaFile(os.path.join(_common.RSRC, b"emptylist.mp3"))
         genre = emptylist.genre
         self.assertEqual(genre, None)
 
     def test_release_time_with_space(self):
         # Ensures that release times delimited by spaces are ignored.
         # Amie Street produces such files.
-        space_time = mediafile.MediaFile(
-            os.path.join(_common.RSRC, b'space_time.mp3')
-        )
+        space_time = mediafile.MediaFile(os.path.join(_common.RSRC, b"space_time.mp3"))
         self.assertEqual(space_time.year, 2009)
         self.assertEqual(space_time.month, 9)
         self.assertEqual(space_time.day, 4)
@@ -52,9 +47,7 @@ class EdgeTest(unittest.TestCase):
     def test_release_time_with_t(self):
         # Ensures that release times delimited by Ts are ignored.
         # The iTunes Store produces such files.
-        t_time = mediafile.MediaFile(
-            os.path.join(_common.RSRC, b't_time.m4a')
-        )
+        t_time = mediafile.MediaFile(os.path.join(_common.RSRC, b"t_time.m4a"))
         self.assertEqual(t_time.year, 1987)
         self.assertEqual(t_time.month, 3)
         self.assertEqual(t_time.day, 31)
@@ -62,74 +55,72 @@ class EdgeTest(unittest.TestCase):
     def test_tempo_with_bpm(self):
         # Some files have a string like "128 BPM" in the tempo field
         # rather than just a number.
-        f = mediafile.MediaFile(os.path.join(_common.RSRC, b'bpm.mp3'))
+        f = mediafile.MediaFile(os.path.join(_common.RSRC, b"bpm.mp3"))
         self.assertEqual(f.bpm, 128)
 
     def test_discc_alternate_field(self):
         # Different taggers use different vorbis comments to reflect
         # the disc and disc count fields: ensure that the alternative
         # style works.
-        f = mediafile.MediaFile(os.path.join(_common.RSRC, b'discc.ogg'))
+        f = mediafile.MediaFile(os.path.join(_common.RSRC, b"discc.ogg"))
         self.assertEqual(f.disc, 4)
         self.assertEqual(f.disctotal, 5)
 
     def test_old_ape_version_bitrate(self):
-        media_file = os.path.join(_common.RSRC, b'oldape.ape')
+        media_file = os.path.join(_common.RSRC, b"oldape.ape")
         f = mediafile.MediaFile(media_file)
         self.assertEqual(f.bitrate, 0)
 
     def test_soundcheck_non_ascii(self):
         # Make sure we don't crash when the iTunes SoundCheck field contains
         # non-ASCII binary data.
-        f = mediafile.MediaFile(os.path.join(_common.RSRC,
-                                             b'soundcheck-nonascii.m4a'))
+        f = mediafile.MediaFile(os.path.join(_common.RSRC, b"soundcheck-nonascii.m4a"))
         self.assertEqual(f.rg_track_gain, 0.0)
 
 
 class InvalidValueToleranceTest(unittest.TestCase):
-
     def test_safe_cast_string_to_int(self):
-        self.assertEqual(_sc(int, u'something'), 0)
+        self.assertEqual(_sc(int, "something"), 0)
 
     def test_safe_cast_string_to_int_with_no_numbers(self):
-        self.assertEqual(_sc(int, u'-'), 0)
+        self.assertEqual(_sc(int, "-"), 0)
 
     def test_safe_cast_int_string_to_int(self):
-        self.assertEqual(_sc(int, u'20'), 20)
+        self.assertEqual(_sc(int, "20"), 20)
 
     def test_safe_cast_string_to_bool(self):
-        self.assertEqual(_sc(bool, u'whatever'), False)
+        self.assertEqual(_sc(bool, "whatever"), False)
 
     def test_safe_cast_intstring_to_bool(self):
-        self.assertEqual(_sc(bool, u'5'), True)
+        self.assertEqual(_sc(bool, "5"), True)
 
     def test_safe_cast_string_to_float(self):
-        self.assertAlmostEqual(_sc(float, u'1.234'), 1.234)
+        self.assertAlmostEqual(_sc(float, "1.234"), 1.234)
 
     def test_safe_cast_int_to_float(self):
         self.assertAlmostEqual(_sc(float, 2), 2.0)
 
     def test_safe_cast_string_with_cruft_to_float(self):
-        self.assertAlmostEqual(_sc(float, u'1.234stuff'), 1.234)
+        self.assertAlmostEqual(_sc(float, "1.234stuff"), 1.234)
 
     def test_safe_cast_negative_string_to_float(self):
-        self.assertAlmostEqual(_sc(float, u'-1.234'), -1.234)
+        self.assertAlmostEqual(_sc(float, "-1.234"), -1.234)
 
     def test_safe_cast_special_chars_to_unicode(self):
-        us = _sc(str, 'caf\xc3\xa9')
+        us = _sc(str, "caf\xc3\xa9")
         self.assertTrue(isinstance(us, str))
-        self.assertTrue(us.startswith(u'caf'))
+        self.assertTrue(us.startswith("caf"))
 
     def test_safe_cast_float_with_no_numbers(self):
-        v = _sc(float, u'+')
+        v = _sc(float, "+")
         self.assertEqual(v, 0.0)
 
     def test_safe_cast_float_with_dot_only(self):
-        v = _sc(float, u'.')
+        v = _sc(float, ".")
         self.assertEqual(v, 0.0)
 
     def test_safe_cast_float_with_multiple_dots(self):
-        v = _sc(float, u'1.0.0')
+        v = _sc(float, "1.0.0")
         self.assertEqual(v, 1.0)
 
 
@@ -140,9 +131,9 @@ class SafetyTest(unittest.TestCase, _common.TempDirMixin):
     def tearDown(self):
         self.remove_temp_dir()
 
-    def _exccheck(self, fn, exc, data=''):
+    def _exccheck(self, fn, exc, data=""):
         fn = os.path.join(self.temp_dir, fn)
-        with open(fn, 'w') as f:
+        with open(fn, "w") as f:
             f.write(data)
         try:
             self.assertRaises(exc, mediafile.MediaFile, fn)
@@ -151,45 +142,42 @@ class SafetyTest(unittest.TestCase, _common.TempDirMixin):
 
     def test_corrupt_mp3_raises_unreadablefileerror(self):
         # Make sure we catch Mutagen reading errors appropriately.
-        self._exccheck(b'corrupt.mp3', mediafile.UnreadableFileError)
+        self._exccheck(b"corrupt.mp3", mediafile.UnreadableFileError)
 
     def test_corrupt_mp4_raises_unreadablefileerror(self):
-        self._exccheck(b'corrupt.m4a', mediafile.UnreadableFileError)
+        self._exccheck(b"corrupt.m4a", mediafile.UnreadableFileError)
 
     def test_corrupt_flac_raises_unreadablefileerror(self):
-        self._exccheck(b'corrupt.flac', mediafile.UnreadableFileError)
+        self._exccheck(b"corrupt.flac", mediafile.UnreadableFileError)
 
     def test_corrupt_ogg_raises_unreadablefileerror(self):
-        self._exccheck(b'corrupt.ogg', mediafile.UnreadableFileError)
+        self._exccheck(b"corrupt.ogg", mediafile.UnreadableFileError)
 
     def test_invalid_ogg_header_raises_unreadablefileerror(self):
-        self._exccheck(b'corrupt.ogg', mediafile.UnreadableFileError,
-                       'OggS\x01vorbis')
+        self._exccheck(b"corrupt.ogg", mediafile.UnreadableFileError, "OggS\x01vorbis")
 
     def test_corrupt_monkeys_raises_unreadablefileerror(self):
-        self._exccheck(b'corrupt.ape', mediafile.UnreadableFileError)
+        self._exccheck(b"corrupt.ape", mediafile.UnreadableFileError)
 
     def test_invalid_extension_raises_filetypeerror(self):
-        self._exccheck(b'something.unknown', mediafile.FileTypeError)
+        self._exccheck(b"something.unknown", mediafile.FileTypeError)
 
     def test_magic_xml_raises_unreadablefileerror(self):
-        self._exccheck(b'nothing.xml', mediafile.UnreadableFileError,
-                       "ftyp")
+        self._exccheck(b"nothing.xml", mediafile.UnreadableFileError, "ftyp")
 
-    @unittest.skipUnless(_common.HAVE_SYMLINK, u'platform lacks symlink')
+    @unittest.skipUnless(_common.HAVE_SYMLINK, "platform lacks symlink")
     def test_broken_symlink(self):
-        fn = os.path.join(_common.RSRC, b'brokenlink')
-        os.symlink('does_not_exist', fn)
+        fn = os.path.join(_common.RSRC, b"brokenlink")
+        os.symlink("does_not_exist", fn)
         try:
-            self.assertRaises(mediafile.UnreadableFileError,
-                              mediafile.MediaFile, fn)
+            self.assertRaises(mediafile.UnreadableFileError, mediafile.MediaFile, fn)
         finally:
             os.unlink(fn)
 
 
 class SideEffectsTest(unittest.TestCase):
     def setUp(self):
-        self.empty = os.path.join(_common.RSRC, b'empty.mp3')
+        self.empty = os.path.join(_common.RSRC, b"empty.mp3")
 
     def test_opening_tagless_file_leaves_untouched(self):
         old_mtime = os.stat(self.empty).st_mtime
@@ -201,8 +189,8 @@ class SideEffectsTest(unittest.TestCase):
 class MP4EncodingTest(unittest.TestCase, _common.TempDirMixin):
     def setUp(self):
         self.create_temp_dir()
-        src = os.path.join(_common.RSRC, b'full.m4a')
-        self.path = os.path.join(self.temp_dir, b'test.m4a')
+        src = os.path.join(_common.RSRC, b"full.m4a")
+        self.path = os.path.join(self.temp_dir, b"test.m4a")
         shutil.copy(src, self.path)
 
         self.mf = mediafile.MediaFile(self.path)
@@ -211,17 +199,17 @@ class MP4EncodingTest(unittest.TestCase, _common.TempDirMixin):
         self.remove_temp_dir()
 
     def test_unicode_label_in_m4a(self):
-        self.mf.label = u'foo\xe8bar'
+        self.mf.label = "foo\xe8bar"
         self.mf.save()
         new_mf = mediafile.MediaFile(self.path)
-        self.assertEqual(new_mf.label, u'foo\xe8bar')
+        self.assertEqual(new_mf.label, "foo\xe8bar")
 
 
 class MP3EncodingTest(unittest.TestCase, _common.TempDirMixin):
     def setUp(self):
         self.create_temp_dir()
-        src = os.path.join(_common.RSRC, b'full.mp3')
-        self.path = os.path.join(self.temp_dir, b'test.mp3')
+        src = os.path.join(_common.RSRC, b"full.mp3")
+        self.path = os.path.join(self.temp_dir, b"test.mp3")
         shutil.copy(src, self.path)
 
         self.mf = mediafile.MediaFile(self.path)
@@ -230,10 +218,10 @@ class MP3EncodingTest(unittest.TestCase, _common.TempDirMixin):
         # Set up the test file with a Latin1-encoded COMM frame. The encoding
         # indices defined by MP3 are listed here:
         # http://id3.org/id3v2.4.0-structure
-        self.mf.mgfile['COMM::eng'].encoding = 0
+        self.mf.mgfile["COMM::eng"].encoding = 0
 
         # Try to store non-Latin1 text.
-        self.mf.comments = u'\u2028'
+        self.mf.comments = "\u2028"
         self.mf.save()
 
 
@@ -246,7 +234,7 @@ class ZeroLengthMediaFile(mediafile.MediaFile):
 class MissingAudioDataTest(unittest.TestCase):
     def setUp(self):
         super(MissingAudioDataTest, self).setUp()
-        path = os.path.join(_common.RSRC, b'full.mp3')
+        path = os.path.join(_common.RSRC, b"full.mp3")
         self.mf = ZeroLengthMediaFile(path)
 
     def test_bitrate_with_zero_length(self):
@@ -257,11 +245,11 @@ class MissingAudioDataTest(unittest.TestCase):
 class TypeTest(unittest.TestCase):
     def setUp(self):
         super(TypeTest, self).setUp()
-        path = os.path.join(_common.RSRC, b'full.mp3')
+        path = os.path.join(_common.RSRC, b"full.mp3")
         self.mf = mediafile.MediaFile(path)
 
     def test_year_integer_in_string(self):
-        self.mf.year = u'2009'
+        self.mf.year = "2009"
         self.assertEqual(self.mf.year, 2009)
 
     def test_set_replaygain_gain_to_none(self):
@@ -296,26 +284,28 @@ class SoundCheckTest(unittest.TestCase):
         self.assertEqual(peak, 1.0)
 
     def test_decode_zero(self):
-        data = b' 80000000 80000000 00000000 00000000 00000000 00000000 ' \
-               b'00000000 00000000 00000000 00000000'
+        data = (
+            b" 80000000 80000000 00000000 00000000 00000000 00000000 "
+            b"00000000 00000000 00000000 00000000"
+        )
         gain, peak = mediafile._sc_decode(data)
         self.assertEqual(gain, 0.0)
         self.assertEqual(peak, 0.0)
 
     def test_malformatted(self):
-        gain, peak = mediafile._sc_decode(b'foo')
+        gain, peak = mediafile._sc_decode(b"foo")
         self.assertEqual(gain, 0.0)
         self.assertEqual(peak, 0.0)
 
     def test_special_characters(self):
-        gain, peak = mediafile._sc_decode(u'caf\xe9'.encode('utf-8'))
+        gain, peak = mediafile._sc_decode("caf\xe9".encode("utf-8"))
         self.assertEqual(gain, 0.0)
         self.assertEqual(peak, 0.0)
 
     def test_decode_handles_unicode(self):
         # Most of the time, we expect to decode the raw bytes. But some formats
         # might give us text strings, which we need to handle.
-        gain, peak = mediafile._sc_decode(u'caf\xe9')
+        gain, peak = mediafile._sc_decode("caf\xe9")
         self.assertEqual(gain, 0.0)
         self.assertEqual(peak, 0.0)
 
@@ -327,12 +317,10 @@ class SoundCheckTest(unittest.TestCase):
 
 
 class ID3v23Test(unittest.TestCase, _common.TempDirMixin):
-    def _make_test(self, ext=b'mp3', id3v23=False):
+    def _make_test(self, ext=b"mp3", id3v23=False):
         self.create_temp_dir()
-        src = os.path.join(_common.RSRC,
-                           b'full.' + ext)
-        self.path = os.path.join(self.temp_dir,
-                                 b'test.' + ext)
+        src = os.path.join(_common.RSRC, b"full." + ext)
+        self.path = os.path.join(self.temp_dir, b"test." + ext)
         shutil.copy(src, self.path)
         return mediafile.MediaFile(self.path, id3v23=id3v23)
 
@@ -344,9 +332,9 @@ class ID3v23Test(unittest.TestCase, _common.TempDirMixin):
         try:
             mf.year = 2013
             mf.save()
-            frame = mf.mgfile['TDRC']
-            self.assertTrue('2013' in str(frame))
-            self.assertTrue('TYER' not in mf.mgfile)
+            frame = mf.mgfile["TDRC"]
+            self.assertTrue("2013" in str(frame))
+            self.assertTrue("TYER" not in mf.mgfile)
         finally:
             self._delete_test()
 
@@ -355,14 +343,14 @@ class ID3v23Test(unittest.TestCase, _common.TempDirMixin):
         try:
             mf.year = 2013
             mf.save()
-            frame = mf.mgfile['TYER']
-            self.assertTrue('2013' in str(frame))
-            self.assertTrue('TDRC' not in mf.mgfile)
+            frame = mf.mgfile["TYER"]
+            self.assertTrue("2013" in str(frame))
+            self.assertTrue("TDRC" not in mf.mgfile)
         finally:
             self._delete_test()
 
     def test_v23_on_non_mp3_is_noop(self):
-        mf = self._make_test(b'm4a', id3v23=True)
+        mf = self._make_test(b"m4a", id3v23=True)
         try:
             mf.year = 2013
             mf.save()
@@ -379,18 +367,21 @@ class ID3v23Test(unittest.TestCase, _common.TempDirMixin):
             mf = self._make_test(id3v23=v23)
             try:
                 mf.images = [
-                    mediafile.Image(b'data', desc=u""),
-                    mediafile.Image(b'data', desc=u"foo"),
-                    mediafile.Image(b'data', desc=u"\u0185"),
+                    mediafile.Image(b"data", desc=""),
+                    mediafile.Image(b"data", desc="foo"),
+                    mediafile.Image(b"data", desc="\u0185"),
                 ]
                 mf.save()
-                apic_frames = mf.mgfile.tags.getall('APIC')
+                apic_frames = mf.mgfile.tags.getall("APIC")
                 encodings = dict([(f.desc, f.encoding) for f in apic_frames])
-                self.assertEqual(encodings, {
-                    u"": mutagen.id3.Encoding.LATIN1,
-                    u"foo": mutagen.id3.Encoding.LATIN1,
-                    u"\u0185": mutagen.id3.Encoding.UTF16,
-                })
+                self.assertEqual(
+                    encodings,
+                    {
+                        "": mutagen.id3.Encoding.LATIN1,
+                        "foo": mutagen.id3.Encoding.LATIN1,
+                        "\u0185": mutagen.id3.Encoding.UTF16,
+                    },
+                )
             finally:
                 self._delete_test()
 
@@ -402,7 +393,8 @@ class ReadOnlyTagTest(unittest.TestCase, _common.TempDirMixin):
         self.field = mediafile.MediaField(
             mediafile.MP3StorageStyle(self.key, read_only=True),
             mediafile.MP4StorageStyle(
-                "----:com.apple.iTunes:" + self.key, read_only=True),
+                "----:com.apple.iTunes:" + self.key, read_only=True
+            ),
             mediafile.StorageStyle(self.key, read_only=True),
             mediafile.ASFStorageStyle(self.key, read_only=True),
         )
@@ -411,14 +403,14 @@ class ReadOnlyTagTest(unittest.TestCase, _common.TempDirMixin):
             mediafile.MediaFile.add_field("read_only_test", self.field)
 
     def test_read(self):
-        path = os.path.join(_common.RSRC, b'empty.flac')
+        path = os.path.join(_common.RSRC, b"empty.flac")
         mf = mediafile.MediaFile(path)
         mf.mgfile.tags[self.key] = "don't"
         self.assertEqual("don't", mf.read_only_test)
 
     def test_write(self):
-        src = os.path.join(_common.RSRC, b'empty.flac')
-        path = os.path.join(self.temp_dir, b'test.flac')
+        src = os.path.join(_common.RSRC, b"empty.flac")
+        path = os.path.join(self.temp_dir, b"test.flac")
         shutil.copy(src, path)
         mf = mediafile.MediaFile(path)
         mf.read_only_field = "something terrible"
@@ -437,5 +429,5 @@ def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,4 @@ deps =
 deps =
     {test,cov}: {[_test]deps}
 commands =
-    py3{6,7,8,9,10,11}-test: python -bb -m pytest {posargs}
+    py3{9,10,11,12,13}-test: python -bb -m pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py310-test, py310-flake8
+envlist = py310-test
 isolated_build = True
 
 [tox:.package]
@@ -14,22 +14,8 @@ basepython = python3
 deps =
     pytest
 
-[_flake8]
-deps =
-    flake8
-    flake8-future-import
-    pep8-naming
-files = mediafile.py test setup.py
-
 [testenv]
 deps =
     {test,cov}: {[_test]deps}
-    py{36,37,38,39,310,311}-flake8: {[_flake8]deps}
 commands =
     py3{6,7,8,9,10,11}-test: python -bb -m pytest {posargs}
-    py36-flake8: flake8 --min-version 3.6 {posargs} {[_flake8]files}
-    py37-flake8: flake8 --min-version 3.7 {posargs} {[_flake8]files}
-    py38-flake8: flake8 --min-version 3.8 {posargs} {[_flake8]files}
-    py39-flake8: flake8 --min-version 3.9 {posargs} {[_flake8]files}
-    py310-flake8: flake8 --min-version 3.10 {posargs} {[_flake8]files}
-    py311-flake8: flake8 --min-version 3.11 {posargs} {[_flake8]files}


### PR DESCRIPTION
Migrated from flake8 to ruff for linting and formatting, updating CI workflows, adding new automation for changelog reminders, and improving contributor documentation.