### PR TITLE
Added MP3DescStorageStyle for LABEL and MEDIA

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,8 @@ v1.0.0
 - Run pyupgrade to align code with Python 3.10+ syntax.
 - Added TSO2 tag to ``albumartist_sort``, matching how Picard >= 1.2, iTunes and
       Swinsian interpret tags.
+- Added ``TXXX:LABEL`` and ``TXXX:MEDIA`` tags to ``label`` and ``media``
+  fields, respectively, for MP3 files.
 
 v0.13.0
 -------

--- a/mediafile/__init__.py
+++ b/mediafile/__init__.py
@@ -496,6 +496,7 @@ class MediaFile:
 
     label = MediaField(
         MP3StorageStyle("TPUB"),
+        MP3DescStorageStyle("LABEL"),
         MP4StorageStyle("----:com.apple.iTunes:LABEL"),
         MP4StorageStyle("----:com.apple.iTunes:publisher"),
         MP4StorageStyle("----:com.apple.iTunes:Label", read_only=True),
@@ -596,6 +597,7 @@ class MediaFile:
     )
     media = MediaField(
         MP3StorageStyle("TMED"),
+        MP3DescStorageStyle("MEDIA"),
         MP4StorageStyle("----:com.apple.iTunes:MEDIA"),
         StorageStyle("MEDIA"),
         ASFStorageStyle("WM/Media"),


### PR DESCRIPTION
This PR adds the `TXXX:LABEL` and `TXXX:MEDIA` to the respective fields in the MediaFile class. 

These fields are read and written by foobar and Mp3Tag.

For references see
https://community.mp3tag.de/t/the-case-for-a-dedicated-label-tag/57647/17 and
https://community.mp3tag.de/t/what-is-the-correct-tag-for-label/59445/2

closes #85

---

**Decision needed:**

Im not entirely sure if we want to have both fields as read and write as this now duplicates the metadata if mediafile is used to write these fields:

```python
f = MediaFile("label.mp3")
f.label = "some label"
f.save()
```
This will now write both the `TXXX:LABEL` and `TPUB` frame (same for media).
```python
from mutagen.id3 import ID3, TXXX, ID3NoHeaderError
tags = ID3("label.mp3")
tags
#{
#'TPUB': TPUB(encoding=<Encoding.UTF8: 3>, text=['some label']),
#'TXXX:LABEL': TXXX(encoding=<Encoding.UTF8: 3>, desc='LABEL', text=['some label'])
#}
```

We could defined these fields as read_only, but this would than still make issues with tools relying on the `TXXX` fields. @JOJ0 Do you know if there is a precedence for this and if we had such an issue beforehand?
